### PR TITLE
Refuse instance creation without reservations

### DIFF
--- a/openstack_dashboard/dashboards/project/instances/workflows/create_instance.py
+++ b/openstack_dashboard/dashboards/project/instances/workflows/create_instance.py
@@ -23,7 +23,9 @@ import operator
 from oslo_utils import units
 from blazardashboard.api import blazar
 
+from django.core.urlresolvers import reverse
 from django.template.defaultfilters import filesizeformat  # noqa
+from django.utils.safestring import mark_safe
 from django.utils.text import normalize_newlines  # noqa
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext_lazy
@@ -49,6 +51,7 @@ from openstack_dashboard.dashboards.project.instances \
 
 
 LOG = logging.getLogger(__name__)
+NO_RESERV = ''
 
 
 class SelectProjectUserAction(workflows.Action):
@@ -82,9 +85,12 @@ class SetInstanceDetailsAction(workflows.Action):
     #availability_zone = forms.ChoiceField(label=_("Availability Zone"),
      #                                     required=False)
 
-    reservation_id = forms.ChoiceField(label=_("Reservation"),
-                                       help_text=_("Choose a reservation to launch this instance against. Only active reservations are displayed as options."),
-                                       required=False)
+    reservation_id = forms.ChoiceField(
+        label=_("Reservation"),
+        help_text=_("Choose a reservation to launch this instance against. "
+                    "Only active reservations are displayed as options."),
+        required=False,
+    )
 
     name = forms.CharField(label=_("Instance Name"),
                            max_length=255)
@@ -366,6 +372,18 @@ class SetInstanceDetailsAction(workflows.Action):
         if check_method:
             check_method(cleaned_data)
 
+    def clean_reservation_id(self):
+        reservation_id = self.cleaned_data.get('reservation_id')
+        if reservation_id == NO_RESERV:
+            raise forms.ValidationError(
+                mark_safe(_( # assuming translations are safe
+                    'A <a href="%(lease_url)s">reservation</a> is required '
+                    'to launch instances'
+                ) % {
+                    'lease_url': reverse('horizon:project:leases:index'),
+                }),
+            )
+
     def clean(self):
         cleaned_data = super(SetInstanceDetailsAction, self).clean()
 
@@ -391,9 +409,7 @@ class SetInstanceDetailsAction(workflows.Action):
                         reservation_ids.append((reservation['id'], label))
 
         if not reservation_ids:
-            reservation_ids.insert(0, ("", _("No reservation found")))
-        else:
-            reservation_ids.append(("", _("Launch without reservation")))
+            reservation_ids.insert(0, (NO_RESERV, _("No reservations active")))
         return reservation_ids
 
     def populate_availability_zone_choices(self, request, context):

--- a/openstack_dashboard/dashboards/project/instances/workflows/create_instance.py
+++ b/openstack_dashboard/dashboards/project/instances/workflows/create_instance.py
@@ -378,7 +378,7 @@ class SetInstanceDetailsAction(workflows.Action):
             raise forms.ValidationError(
                 mark_safe(_( # assuming translations are safe
                     'An active <a href="%(lease_url)s">reservation</a> is required '
-                    'to launch instances'
+                    'to launch instances.'
                 ) % {
                     'lease_url': reverse('horizon:project:leases:index'),
                 }),
@@ -414,7 +414,7 @@ class SetInstanceDetailsAction(workflows.Action):
             reservation_ids.insert(0, (NO_RESERV, _("No reservations active")))
             msg = mark_safe(_( # assuming translations are safe
                 'An active <a href="%(lease_url)s">reservation</a> is required '
-                'to launch instances'
+                'to launch instances.'
             ) % {
                 'lease_url': reverse('horizon:project:leases:index'),
             })


### PR DESCRIPTION
Almost always causes a problem on CHI anyways. Repeat PR from #1, which was incomplete.

> I'm not sure why [`required=False` on the reservation ID](https://github.com/ChameleonCloud/horizon/blob/93503618ff0c09f3f6076395e3cb1c0d4470c6d3/openstack_dashboard/dashboards/project/instances/workflows/create_instance.py#L92), it's now effectively forced by the [`clean_reservation_id()` method](https://github.com/ChameleonCloud/horizon/blob/93503618ff0c09f3f6076395e3cb1c0d4470c6d3/openstack_dashboard/dashboards/project/instances/workflows/create_instance.py#L375) I added anyways, so it's moot as far as I can tell.