### PR TITLE
Use cache to store appliance data

### DIFF
--- a/openstack_dashboard/api/glance.py
+++ b/openstack_dashboard/api/glance.py
@@ -40,9 +40,13 @@ from horizon.utils.memoized import memoized
 from openstack_dashboard.api import base
 from openstack_dashboard.contrib.developer.profiler import api as profiler
 
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 LOG = logging.getLogger(__name__)
 VERSIONS = base.APIVersionManager("image", preferred_version=2)
+
+
 
 try:
     from glanceclient.v2 import client as glance_client_v2
@@ -153,23 +157,25 @@ class Image(base.APIResourceWrapper):
         return not self.__eq__(other_image)
 
     def get_catalog_id(self):
-        if Image.PUBLISHED_APPLIANCES.get(self.id):
-            return Image.PUBLISHED_APPLIANCES.get(self.id).get('id', -1)
+        if cache.get('published_appliances', {}).get(self.id):
+            return cache.get('published_appliances', {}).get(self.id).get('id', -1)
         return -1
 
     def get_is_project_supported(self):
-        if Image.PUBLISHED_APPLIANCES.get(self.id):
-            return Image.PUBLISHED_APPLIANCES.get(self.id).get('project_supported', False)
+        if cache.get('published_appliances', {}).get(self.id):
+            return cache.get('published_appliances', {}).get(self.id).get('project_supported', False)
         return False
 
     def get_is_published_in_app_catalog(self):
-        return Image.PUBLISHED_APPLIANCES.get(self.id) is not None
+        return cache.get('published_appliances', {}).get(self.id) is not None
 
 def fetch_published_appliances():
-    if not cache.get('app_catalog_updated'):
+    if not cache.get('app_catalog_updated', False) or not cache.get('published_appliances', False):
         try:
-            LOG.info('Fetching appliances from ' + settings.CHAMELEON_PORTAL_API_BASE_URL + settings.APPLIANCE_CATALOG_API_PATH)
-            appliance_list = requests.get(settings.CHAMELEON_PORTAL_API_BASE_URL + settings.APPLIANCE_CATALOG_API_PATH).json().get('result')
+            LOG.info('Fetching appliances from ' + settings.CHAMELEON_PORTAL_API_BASE_URL\
+                + settings.APPLIANCE_CATALOG_API_PATH)
+            appliance_list = requests.get(settings.CHAMELEON_PORTAL_API_BASE_URL\
+                + settings.APPLIANCE_CATALOG_API_PATH).json().get('result')
             appliance_dict = {}
             for appliance in appliance_list:
                 if appliance.get('chi_uc_appliance_id', False):
@@ -178,8 +184,8 @@ def fetch_published_appliances():
                     appliance_dict[appliance.get('chi_tacc_appliance_id')] = appliance
                 if appliance.get('kvm_tacc_appliance_id', False):
                     appliance_dict[appliance.get('kvm_tacc_appliance_id')] = appliance
-            Image.PUBLISHED_APPLIANCES = appliance_dict
-            cache.set('app_catalog_updated', True, 60*5)
+            cache.set('published_appliances', appliance_dict, 60*15)
+            cache.set('app_catalog_updated', True, 60*10)
         except Exception as e:
             LOG.error(e)
 

--- a/openstack_dashboard/api/glance.py
+++ b/openstack_dashboard/api/glance.py
@@ -46,8 +46,6 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 LOG = logging.getLogger(__name__)
 VERSIONS = base.APIVersionManager("image", preferred_version=2)
 
-
-
 try:
     from glanceclient.v2 import client as glance_client_v2
     VERSIONS.load_supported_version(2, {"client": glance_client_v2,
@@ -157,20 +155,16 @@ class Image(base.APIResourceWrapper):
         return not self.__eq__(other_image)
 
     def get_catalog_id(self):
-        if cache.get('published_appliances', {}).get(self.id):
-            return cache.get('published_appliances', {}).get(self.id).get('id', -1)
-        return -1
+        return cache.get('published_appliances', {}).get(self.id, {}).get('id', -1)
 
     def get_is_project_supported(self):
-        if cache.get('published_appliances', {}).get(self.id):
-            return cache.get('published_appliances', {}).get(self.id).get('project_supported', False)
-        return False
+        return cache.get('published_appliances', {}).get(self.id, {}).get('project_supported', False)
 
     def get_is_published_in_app_catalog(self):
         return cache.get('published_appliances', {}).get(self.id) is not None
 
 def fetch_published_appliances():
-    if not cache.get('app_catalog_updated', False) or not cache.get('published_appliances', False):
+    if not cache.get('published_appliances', False):
         try:
             LOG.info('Fetching appliances from ' + settings.CHAMELEON_PORTAL_API_BASE_URL\
                 + settings.APPLIANCE_CATALOG_API_PATH)
@@ -185,7 +179,7 @@ def fetch_published_appliances():
                 if appliance.get('kvm_tacc_appliance_id', False):
                     appliance_dict[appliance.get('kvm_tacc_appliance_id')] = appliance
             cache.set('published_appliances', appliance_dict, 60*15)
-            cache.set('app_catalog_updated', True, 60*10)
+            LOG.info('Appliance Catalog cache updated')
         except Exception as e:
             LOG.error(e)
 


### PR DESCRIPTION
Using cache to store appliance data should allow access to the same cached data across workers