### PR TITLE
[swift] better error message when container name exists

### DIFF
--- a/horizon/static/framework/framework.module.js
+++ b/horizon/static/framework/framework.module.js
@@ -126,11 +126,12 @@
   function httpRedirectLogin($q, $rootScope, $window, frameworkEvents, toastService) {
     return {
       responseError: function (error) {
-        if (error.status === 401) {
+        var isRedirect = typeof error.config.redirectOnAuthErrors === "boolean" ? error.config.redirectOnAuthErrors : true
+        if (error.status === 401 && isRedirect) {
           var msg = gettext('Unauthorized. Redirecting to login');
           handleRedirectMessage(msg, $rootScope, $window, frameworkEvents, toastService, true);
         }
-        if (error.status === 403) {
+        if (error.status === 403 && isRedirect) {
           var msg2 = gettext('Forbidden. Insufficient permissions of the requested operation');
           handleRedirectMessage(msg2, $rootScope, $window, frameworkEvents, toastService, false);
         }

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/containers/containers.controller.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/containers/containers.controller.js
@@ -96,7 +96,9 @@
       var def = $q.defer();
       // reverse the sense here - successful lookup == error so we reject the
       // name if we find it in swift
-      swiftAPI.getContainer(containerName, true).then(def.reject, def.resolve);
+      swiftAPI.getContainer(containerName, true, {redirectOnAuthErrors: false}).then(def.reject, function(response){
+    	  if (response.status == 403) {def.reject(response)}
+    	  else {def.resolve(response)}});
       return def.promise;
     }
 
@@ -201,7 +203,7 @@
               {
                 key: 'name',
                 validationMessage: {
-                  exists: gettext('A container with that name exists.')
+                  exists: gettext('A container with that name exists. (Name must be unique within each region.)')
                 },
                 $asyncValidators: {
                   exists: checkContainerNameConflict

--- a/openstack_dashboard/static/app/core/openstack-service-api/swift.service.js
+++ b/openstack_dashboard/static/app/core/openstack-service-api/swift.service.js
@@ -116,8 +116,8 @@
      * @returns {Object} An object with the metadata fields.
      *
      */
-    function getContainer(container, ignoreError) {
-      var promise = apiService.get(service.getContainerURL(container) + '/metadata/');
+    function getContainer(container, ignoreError, config) {
+      var promise = apiService.get(service.getContainerURL(container) + '/metadata/', config || {});
       if (ignoreError) {
         return promise.error(angular.noop);
       }


### PR DESCRIPTION
Container name has to be unique within a region. When trying to create/list a container with the name that is already taken by other projects, swift api will return 403 error. This can be verified by using the swift CLI.

There's a global interceptor "httpRedirectLogin" that checks all http requests, and if 403 error is detected, it will show a "Forbidden: Insufficient permissions of the requested operation" error message. This can be verified in either UC or TACC prod horizon.

The updates in this PR solve the problem by introducing "ignore" flags to the "httpRedirectLogin" interceptor and asking "checkContainerNameConflict" to treat 403 error as duplicate container names. 

The changes are deployed to dev@tacc. so you can check there. 