### PR TITLE
Update instance actions to show only supported actions

### DIFF
--- a/openstack_dashboard/dashboards/project/instances/tables.py
+++ b/openstack_dashboard/dashboards/project/instances/tables.py
@@ -1302,14 +1302,7 @@ class InstancesTable(tables.DataTable):
             launch_actions = (LaunchLinkNG,) + launch_actions
         table_actions = launch_actions + (DeleteInstance,
                                           InstancesFilterAction)
-        row_actions = (StartInstance, ConfirmResize, RevertResize,
-                       AttachInterface, DetachInterface, EditInstance,
-                       UpdateMetadata, DecryptInstancePassword,
-                       EditInstanceSecurityGroups,
-                       EditPortSecurityGroups,
-                       ConsoleLink, LogLink,
-                       RescueInstance, UnRescueInstance,
-                       TogglePause, ToggleSuspend, ToggleShelve,
-                       ResizeLink, LockInstance, UnlockInstance,
-                       SoftRebootInstance, RebootInstance,
-                       StopInstance, RebuildInstance, DeleteInstance)
+        row_actions = (StartInstance, AttachInterface, DetachInterface,
+                       EditInstance, ConsoleLink, SoftRebootInstance,
+                       RebootInstance, StopInstance, RebuildInstance,
+                       DeleteInstance)


### PR DESCRIPTION
Looks like some of these got cut out after rebasing (see rocky commit: 15e2687cd8319e095d3d7380665f1a73d2d69e9d). Rescue and Unrescue are new, but also not supported.