### PR TITLE
Generate v3oidc openrc files for federated users

### DIFF
--- a/openstack_auth/user.py
+++ b/openstack_auth/user.py
@@ -67,6 +67,8 @@ def create_user_from_token(request, token, endpoint, services_region=None):
                 endpoint=endpoint,
                 services_region=svc_region,
                 is_federated=getattr(token, 'is_federated', False),
+                federated_idp=getattr(token, 'federated_idp', None),
+                federated_protocol=getattr(token, 'federated_protocol', None),
                 unscoped_token=getattr(token, 'unscoped_token',
                                        request.session.get('unscoped_token')))
 
@@ -116,6 +118,10 @@ class Token(object):
         self.is_federated = auth_ref.is_federated
         self.roles = [{'name': role} for role in auth_ref.role_names]
         self.serviceCatalog = auth_ref.service_catalog.catalog
+        self.federated_idp = (auth_ref._user.get('OS-FEDERATION', {})
+            .get('identity_provider', {}).get('id'))
+        self.federated_protocol = (auth_ref._user.get('OS-FEDERATION', {})
+            .get('protocol', {}).get('id'))
 
 
 class User(models.AbstractBaseUser, models.AnonymousUser):
@@ -201,6 +207,7 @@ class User(models.AbstractBaseUser, models.AnonymousUser):
                  services_region=None, user_domain_id=None,
                  user_domain_name=None, domain_id=None, domain_name=None,
                  project_id=None, project_name=None, is_federated=False,
+                 federated_idp=None, federated_protocol=None,
                  unscoped_token=None, password=None, password_expires_at=None):
         self.id = id
         self.pk = id
@@ -223,6 +230,8 @@ class User(models.AbstractBaseUser, models.AnonymousUser):
         self.enabled = enabled
         self._authorized_tenants = authorized_tenants
         self.is_federated = is_federated
+        self.federated_idp = federated_idp
+        self.federated_protocol = federated_protocol
         self.password_expires_at = password_expires_at
 
         # Unscoped token is used for listing user's project that works

--- a/openstack_dashboard/dashboards/project/api_access/templates/api_access/openrc.sh.template
+++ b/openstack_dashboard/dashboards/project/api_access/templates/api_access/openrc.sh.template
@@ -30,10 +30,18 @@ unset OS_TENANT_NAME
 # performing the action as the **user**.
 export OS_USERNAME="{{ user.username|shellfilter }}"
 
-# With Keystone you pass the keystone password.
-echo "Please enter your OpenStack Password for project $OS_PROJECT_NAME as user $OS_USERNAME: "
+{% if user.is_federated %}
+export OS_IDENTITY_PROVIDER="{{ user.federated_idp }}"
+export OS_PROTOCOL="{{ user.federated_protocol }}"
+echo "Please enter your OpenStack password for user $OS_USERNAME: "
 read -sr OS_PASSWORD_INPUT
 export OS_PASSWORD=$OS_PASSWORD_INPUT
+{% else %}
+# With Keystone you pass the keystone password.
+echo "Please enter your OpenStack password for user $OS_USERNAME: "
+read -sr OS_PASSWORD_INPUT
+export OS_PASSWORD=$OS_PASSWORD_INPUT
+{% endif %}
 
 # If your configuration has multiple regions, we set that information here.
 # OS_REGION_NAME is optional and only valid in certain environments.


### PR DESCRIPTION
When the user is logging in via federation, it no longer makes sense to
generate v3password-style RC files, as they will probably not be able to
log in with this method. Instead, generate a placeholder configuration
that works with some supported method, in this default, v3oidcpassword.

This should probably be configurable long-term somehow.