### PR TITLE
Pass services_region to WebSSO default URL

### DIFF
--- a/openstack_auth/utils.py
+++ b/openstack_auth/utils.py
@@ -271,8 +271,9 @@ def get_websso_url(request, auth_url, websso_auth):
             # If the IdP is not found (or was explicitly undefined), and
             # there is a default URL set, prefer it over WebSSO by protocol.
             host = request.get_host()
-            url = ('%s?origin=%s&host=%s' %
-                  (get_websso_default_redirect_url(), origin, host))
+            url = ('%s?origin=%s&host=%s&services_region=%s' %
+                  (get_websso_default_redirect_url(), origin, host,
+                   request.COOKIES.get('services_region')))
         else:
             # If no IDP mapping found for the identifier,
             # perform WebSSO by protocol.

--- a/openstack_auth/views.py
+++ b/openstack_auth/views.py
@@ -60,9 +60,8 @@ def login(request):
             utils.is_websso_default_redirect(request)):
         origin = utils.build_absolute_uri(request, '/auth/websso/')
         if utils.get_websso_default_redirect_url():
-            host = request.get_host()
-            url = ('%s?origin=%s&host=%s' % (
-                utils.get_websso_default_redirect_url(), origin, host))
+            auth_url = getattr(settings, 'WEBSSO_KEYSTONE_URL', None)
+            url = utils.get_websso_url(request, auth_url, None)
         else:
             protocol = utils.get_websso_default_redirect_protocol()
             region = utils.get_websso_default_redirect_region()


### PR DESCRIPTION
This is so the Chameleon user portal can understand on which region to
provision the accounts on-demand in the old SSO solution.