### PR TITLE
Add official image filter to images table

### DIFF
--- a/horizon/static/framework/widgets/table/hz-dynamic-table.html
+++ b/horizon/static/framework/widgets/table/hz-dynamic-table.html
@@ -72,7 +72,6 @@
             </div>
           </td>
           <td style="width: 4em;max-width: 5em;" ng-show="config.expand" class="expander">
-            <img title="Chameleon Supported Appliance" style="float:right;" ng-if="item.project_supported" height="20px" src="https://www.chameleoncloud.org/static/images/logo-small.png" />
             <div class="fa fa-chevron-right"
               hz-expand-detail
               duration="200">

--- a/horizon/static/framework/widgets/table/hz-dynamic-table.html
+++ b/horizon/static/framework/widgets/table/hz-dynamic-table.html
@@ -80,12 +80,10 @@
           <td ng-repeat="column in config.columns"
             class="rsp-p{$ column.priority $} {$ column.classes $}"
             ng-if="columnAllowed(column)">
-                <hz-cell table="table" column="column" item="item" ng-if="column.classes.includes('chameleon-supported')">
-                  <img title="Chameleon Supported Appliance" alt="Chameleon Supported Appliance"
-                       ng-if="item.project_supported" height="20px"
-                       src="https://www.chameleoncloud.org/static/images/logo-small.png" />
-                </hz-cell>
-                <hz-cell table="table" column="column" item="item" ng-if="!column.classes.includes('chameleon-supported')"></hz-cell>
+              <hz-cell table="table" column="column" item="item"></hz-cell>
+              <img title="Chameleon Supported Appliance" alt="Chameleon Supported Appliance"
+                ng-if="item.project_supported && column.classes.includes('chameleon-supported')" height="20px"
+                src="https://www.chameleoncloud.org/static/images/logo-small.png" />
           </td>
           <td ng-if="itemActions" class="actions_column">
             <!--

--- a/horizon/static/framework/widgets/table/hz-dynamic-table.html
+++ b/horizon/static/framework/widgets/table/hz-dynamic-table.html
@@ -80,7 +80,9 @@
           <td ng-repeat="column in config.columns"
             class="rsp-p{$ column.priority $} {$ column.classes $}"
             ng-if="columnAllowed(column)">
-            <hz-cell table="table" column="column" item="item"></hz-cell>
+              <hz-cell table="table" column="column" item="item">
+                <img title="Chameleon Supported Appliance" style="float:right;" ng-if="item.project_supported" height="20px" src="https://www.chameleoncloud.org/static/images/logo-small.png" />
+              </hz-cell>
           </td>
           <td ng-if="itemActions" class="actions_column">
             <!--

--- a/horizon/static/framework/widgets/table/hz-dynamic-table.html
+++ b/horizon/static/framework/widgets/table/hz-dynamic-table.html
@@ -80,9 +80,9 @@
           <td ng-repeat="column in config.columns"
             class="rsp-p{$ column.priority $} {$ column.classes $}"
             ng-if="columnAllowed(column)">
-                <hz-cell table="table" column="column" ng-if="column.classes.includes('chameleon-supported')">
+                <hz-cell table="table" column="column" item="item" ng-if="column.classes.includes('chameleon-supported')">
                   <img title="Chameleon Supported Appliance" alt="Chameleon Supported Appliance"
-                       style="float:right;" ng-if="item.project_supported" height="20px"
+                       ng-if="item.project_supported" height="20px"
                        src="https://www.chameleoncloud.org/static/images/logo-small.png" />
                 </hz-cell>
                 <hz-cell table="table" column="column" item="item" ng-if="!column.classes.includes('chameleon-supported')"></hz-cell>

--- a/horizon/static/framework/widgets/table/hz-dynamic-table.html
+++ b/horizon/static/framework/widgets/table/hz-dynamic-table.html
@@ -80,12 +80,12 @@
           <td ng-repeat="column in config.columns"
             class="rsp-p{$ column.priority $} {$ column.classes $}"
             ng-if="columnAllowed(column)">
-                <hz-cell table="table" column="column" ng-if="'chameleon-supported' in column.classes">
+                <hz-cell table="table" column="column" ng-if="column.classes.includes('chameleon-supported')">
                   <img title="Chameleon Supported Appliance" alt="Chameleon Supported Appliance"
                        style="float:right;" ng-if="item.project_supported" height="20px"
                        src="https://www.chameleoncloud.org/static/images/logo-small.png" />
                 </hz-cell>
-                <hz-cell table="table" column="column" item="item" ng-if="!'chameleon-supported' in column.classes"></hz-cell>
+                <hz-cell table="table" column="column" item="item" ng-if="!column.classes.includes('chameleon-supported')"></hz-cell>
           </td>
           <td ng-if="itemActions" class="actions_column">
             <!--

--- a/horizon/static/framework/widgets/table/hz-dynamic-table.html
+++ b/horizon/static/framework/widgets/table/hz-dynamic-table.html
@@ -80,15 +80,12 @@
           <td ng-repeat="column in config.columns"
             class="rsp-p{$ column.priority $} {$ column.classes $}"
             ng-if="columnAllowed(column)">
-              {% if "chameleon-supported" in column.classes %}
-                <hz-cell table="table" column="column">
+                <hz-cell table="table" column="column" ng-if="'chameleon-supported' in column.classes">
                   <img title="Chameleon Supported Appliance" alt="Chameleon Supported Appliance"
                        style="float:right;" ng-if="item.project_supported" height="20px"
                        src="https://www.chameleoncloud.org/static/images/logo-small.png" />
                 </hz-cell>
-              {% else %}
-                  <hz-cell table="table" column="column" item="item"></hz-cell>
-              {% endif %}
+                <hz-cell table="table" column="column" item="item" ng-if="!'chameleon-supported' in column.classes"></hz-cell>
           </td>
           <td ng-if="itemActions" class="actions_column">
             <!--

--- a/horizon/static/framework/widgets/table/hz-dynamic-table.html
+++ b/horizon/static/framework/widgets/table/hz-dynamic-table.html
@@ -80,9 +80,15 @@
           <td ng-repeat="column in config.columns"
             class="rsp-p{$ column.priority $} {$ column.classes $}"
             ng-if="columnAllowed(column)">
-              <hz-cell table="table" column="column" item="item">
-                <img title="Chameleon Supported Appliance" style="float:right;" ng-if="item.project_supported" height="20px" src="https://www.chameleoncloud.org/static/images/logo-small.png" />
-              </hz-cell>
+              {% if "chameleon-supported" in column.classes %}
+                <hz-cell table="table" column="column">
+                  <img title="Chameleon Supported Appliance" alt="Chameleon Supported Appliance"
+                       style="float:right;" ng-if="item.project_supported" height="20px"
+                       src="https://www.chameleoncloud.org/static/images/logo-small.png" />
+                </hz-cell>
+              {% else %}
+                  <hz-cell table="table" column="column" item="item"></hz-cell>
+              {% endif %}
           </td>
           <td ng-if="itemActions" class="actions_column">
             <!--

--- a/openstack_dashboard/api/glance.py
+++ b/openstack_dashboard/api/glance.py
@@ -153,6 +153,7 @@ def fetch_published_appliances():
             appliance_list = requests.get(settings.CHAMELEON_PORTAL_API_BASE_URL\
                 + settings.APPLIANCE_CATALOG_API_PATH).json().get('result')
             appliance_dict = {}
+            LOG.info(f"Found {len(appliance_list)} appliances")
             for appliance in appliance_list:
                 if appliance.get('chi_uc_appliance_id', False):
                     appliance_dict[appliance.get('chi_uc_appliance_id')] = appliance

--- a/openstack_dashboard/dashboards/project/images/images/tables.py
+++ b/openstack_dashboard/dashboards/project/images/images/tables.py
@@ -343,6 +343,7 @@ class ImagesTable(tables.DataTable):
                          attrs=({"data-type": "size"}),
                          verbose_name=_("Size"))
     chameleon_supported = tables.Column(get_is_supported,
+                                        classes=("chameleon-supported",),
                                         filters=(filters.yesno, filters.capfirst),
                                         verbose_name=_("Chameleon Supported"))
 

--- a/openstack_dashboard/dashboards/project/images/images/tables.py
+++ b/openstack_dashboard/dashboards/project/images/images/tables.py
@@ -345,6 +345,7 @@ class ImagesTable(tables.DataTable):
     chameleon_supported = tables.Column(get_is_supported,
                                         classes=("chameleon-supported",),
                                         filters=(filters.yesno, filters.capfirst),
+                                        empty_value=False,
                                         verbose_name=_("Chameleon Supported"))
 
     class Meta(object):

--- a/openstack_dashboard/dashboards/project/images/images/tables.py
+++ b/openstack_dashboard/dashboards/project/images/images/tables.py
@@ -272,6 +272,9 @@ def get_format(image):
         return pgettext_lazy("Image format for display in table", "Raw")
     return format.upper()
 
+def get_is_official(image):
+    return getattr(image, "project_supported", False)
+
 
 class UpdateRow(tables.Row):
     ajax = True
@@ -339,6 +342,9 @@ class ImagesTable(tables.DataTable):
                          filters=(filters.filesizeformat,),
                          attrs=({"data-type": "size"}),
                          verbose_name=_("Size"))
+    official = tables.Column(get_is_official,
+                             filters=(filters.yesno, filters.capfirst),
+                             verbose_name=_("Official"))
 
     class Meta(object):
         name = "images"

--- a/openstack_dashboard/dashboards/project/images/images/tables.py
+++ b/openstack_dashboard/dashboards/project/images/images/tables.py
@@ -293,6 +293,22 @@ class UpdateRow(tables.Row):
             self.classes.append('category-' + category)
 
 
+@filters.register.filter(is_safe=False)
+@filters.stringfilter
+def chameleon_logo(value):
+    """
+    Accepts a yes/no value and translates it into "" or " ". This is used to match against a CSS
+    selector to emplace a Chameleon logo for empty elements. This is incredibly hacky, but columns
+    do not appear to allow conditional CSS classes for each row, and rather blanket apply the classes
+    to every row. This means the condition HAS to be checked in the CSS, and this seemed like the
+    easiest way to do it.
+    """
+    if value.lower().trim() == "yes":
+        return ""
+    else:
+        return " "
+
+
 class ImagesTable(tables.DataTable):
     STATUS_CHOICES = (
         ("active", True),
@@ -343,7 +359,8 @@ class ImagesTable(tables.DataTable):
                          attrs=({"data-type": "size"}),
                          verbose_name=_("Size"))
     chameleon_supported = tables.Column(get_is_supported,
-                                        filters=(filters.yesno, filters.capfirst),
+                                        filters=(filters.yesno, chameleon_logo),
+                                        classes=(".chameleon-supported",),
                                         verbose_name=_("Chameleon Supported"))
 
     class Meta(object):

--- a/openstack_dashboard/dashboards/project/images/images/tables.py
+++ b/openstack_dashboard/dashboards/project/images/images/tables.py
@@ -272,7 +272,7 @@ def get_format(image):
         return pgettext_lazy("Image format for display in table", "Raw")
     return format.upper()
 
-def get_is_official(image):
+def get_is_supported(image):
     return getattr(image, "project_supported", False)
 
 
@@ -342,9 +342,9 @@ class ImagesTable(tables.DataTable):
                          filters=(filters.filesizeformat,),
                          attrs=({"data-type": "size"}),
                          verbose_name=_("Size"))
-    official = tables.Column(get_is_official,
-                             filters=(filters.yesno, filters.capfirst),
-                             verbose_name=_("Official"))
+    chameleon_supported = tables.Column(get_is_supported,
+                                        filters=(filters.yesno, filters.capfirst),
+                                        verbose_name=_("Chameleon Supported"))
 
     class Meta(object):
         name = "images"

--- a/openstack_dashboard/dashboards/project/images/images/tables.py
+++ b/openstack_dashboard/dashboards/project/images/images/tables.py
@@ -293,22 +293,6 @@ class UpdateRow(tables.Row):
             self.classes.append('category-' + category)
 
 
-@filters.register.filter(is_safe=False)
-@filters.stringfilter
-def chameleon_logo(value):
-    """
-    Accepts a yes/no value and translates it into "" or " ". This is used to match against a CSS
-    selector to emplace a Chameleon logo for empty elements. This is incredibly hacky, but columns
-    do not appear to allow conditional CSS classes for each row, and rather blanket apply the classes
-    to every row. This means the condition HAS to be checked in the CSS, and this seemed like the
-    easiest way to do it.
-    """
-    if value.lower().trim() == "yes":
-        return ""
-    else:
-        return " "
-
-
 class ImagesTable(tables.DataTable):
     STATUS_CHOICES = (
         ("active", True),
@@ -359,8 +343,7 @@ class ImagesTable(tables.DataTable):
                          attrs=({"data-type": "size"}),
                          verbose_name=_("Size"))
     chameleon_supported = tables.Column(get_is_supported,
-                                        filters=(filters.yesno, chameleon_logo),
-                                        classes=(".chameleon-supported",),
+                                        filters=(filters.yesno, filters.capfirst),
                                         verbose_name=_("Chameleon Supported"))
 
     class Meta(object):

--- a/openstack_dashboard/dashboards/project/images/templates/images/images/_detail_overview.html
+++ b/openstack_dashboard/dashboards/project/images/templates/images/images/_detail_overview.html
@@ -32,7 +32,7 @@
     {% else %}
       <dd>{% trans "Never updated" %}</dd>
     {% endif %}
-    <dt>{% trans "Official" %}</dt>
+    <dt>{% trans "Chameleon Supported" %}</dt>
     <dd>{{  image.project_supported|yesno|capfirst }}</dd>
   </dl>
 

--- a/openstack_dashboard/dashboards/project/images/templates/images/images/_detail_overview.html
+++ b/openstack_dashboard/dashboards/project/images/templates/images/images/_detail_overview.html
@@ -32,6 +32,8 @@
     {% else %}
       <dd>{% trans "Never updated" %}</dd>
     {% endif %}
+    <dt>{% trans "Official" %}</dt>
+    <dd>{{  image.project_supported|yesno|capfirst }}</dd>
   </dl>
 
   <h4>{% trans "Specs" %}</h4>

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/source/source.controller.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/source/source.controller.js
@@ -166,6 +166,8 @@
     var tableColumnsMap = {
       image: [
         { id: 'name_or_id', title: gettext('Name'), priority: 1 },
+        { id: 'project_supported', title: gettext('Chameleon Supported'),
+          filters: ['yesno'], priority: 2 },
         { id: 'updated_at', title: gettext('Updated'), filters: ['simpleDate'], priority: 2 },
         { id: 'size', title: gettext('Size'), filters: ['bytes'], priority: 2 },
         { id: 'disk_format', title: gettext('Format'),
@@ -255,6 +257,14 @@
         name: 'name',
         singleton: true
       },
+      project_supported: {
+        label: gettext('Chameleon Supported'),
+        name: 'chameleon_supported',
+        options: [
+          { label: gettext('Yes'), key: 'true' },
+          { label: gettext('No'), key: 'false' },
+        ]
+      },
       size: {
         label: gettext('Size'),
         name: 'size',
@@ -299,7 +309,7 @@
     // Mapping for filter facets based on boot source type
     var sourceTypeFacets = {
       image: [
-        facets.name, facets.updated, facets.size, facets.type, facets.visibility
+        facets.name, facets.project_supported, facets.updated, facets.size, facets.type, facets.visibility
       ],
       snapshot: [
         facets.name, facets.updated, facets.size, facets.type, facets.visibility

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/source/source.controller.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/source/source.controller.js
@@ -172,7 +172,7 @@
         { id: 'size', title: gettext('Size'), filters: ['bytes'], priority: 2 },
         { id: 'disk_format', title: gettext('Format'),
           filters: [getImageDiskFormat], priority: 2 },
-        { id: 'visibility', title: gettext('Visibility'), filters: [getVisibility], priority: 2 }
+        // { id: 'visibility', title: gettext('Visibility'), filters: [getVisibility], priority: 2 }
       ],
       snapshot: [
         { id: 'name', title: gettext('Name'), priority: 1 },
@@ -288,17 +288,19 @@
         name: 'updated_at',
         singleton: true
       },
-      visibility: {
-        label: gettext('Visibility'),
-        name: 'visibility',
-        singleton: true,
-        options: [
-          { label: gettext('Public'), key: 'public' },
-          { label: gettext('Private'), key: 'private' },
-          { label: gettext('Shared With Project'), key: 'shared' },
-          { label: gettext('Community'), key: 'community' }
-        ]
-      },
+      // To simplify the table, hide visibility since it's not
+      // super import information when creating an instance
+      // visibility: {
+      //   label: gettext('Visibility'),
+      //   name: 'visibility',
+      //   singleton: true,
+      //   options: [
+      //     { label: gettext('Public'), key: 'public' },
+      //     { label: gettext('Private'), key: 'private' },
+      //     { label: gettext('Shared With Project'), key: 'shared' },
+      //     { label: gettext('Community'), key: 'community' }
+      //   ]
+      // },
       volumeType: {
         label: gettext('Type'),
         name: 'volume_image_metadata.disk_format',

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/source/source.controller.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/source/source.controller.js
@@ -167,7 +167,7 @@
       image: [
         { id: 'name_or_id', title: gettext('Name'), priority: 1 },
         { id: 'project_supported', title: gettext('Chameleon Supported'),
-          filters: ['yesno'], priority: 2 },
+          filters: ['yesno'], classes: 'chameleon-supported', priority: 2 },
         { id: 'updated_at', title: gettext('Updated'), filters: ['simpleDate'], priority: 2 },
         { id: 'size', title: gettext('Size'), filters: ['bytes'], priority: 2 },
         { id: 'disk_format', title: gettext('Format'),
@@ -260,6 +260,7 @@
       project_supported: {
         label: gettext('Chameleon Supported'),
         name: 'chameleon_supported',
+        classes: 'chameleon-supported',
         options: [
           { label: gettext('Yes'), key: 'true' },
           { label: gettext('No'), key: 'false' },

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -254,7 +254,7 @@
   function imageProperties(imagesService, statuses) {
     return {
       id: gettext('ID'),
-      project_supported: { label: gettext('Official'), filters: ['yesno'] },
+      project_supported: { label: gettext('Chameleon Supported'), filters: ['chameleon_logo'] },
       checksum: gettext('Checksum'),
       members: gettext('Members'),
       min_disk: gettext('Min. Disk'),

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -139,8 +139,8 @@
         singleton: true,
         persistent: true,
         options: [
-          {label: gettext('Yes'), key: 'true'},
-          {label: gettext('No'), key: 'false'}
+          {label: gettext('Yes'), key: 'yes'},
+          {label: gettext('No'), key: 'no'}
         ]
       })
       .append({

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -139,8 +139,8 @@
         singleton: true,
         persistent: true,
         options: [
-          {label: gettext('Yes'), key: 'Yes'},
-          {label: gettext('No'), key: 'No'}
+          {label: gettext('Yes'), key: 'true'},
+          {label: gettext('No'), key: 'false'}
         ]
       })
       .append({

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -137,7 +137,6 @@
         classes: 'chameleon-supported',
         isServer: true,
         singleton: true,
-        persistent: true,
         options: [
           {label: gettext('Yes'), key: 'true'},
           {label: gettext('No'), key: 'false'}

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -94,6 +94,7 @@
       })
       .append({
         id: 'project_supported',
+        classes: "chameleon-supported",
         priority: 1
       })
       .append({

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -131,7 +131,7 @@
         persistent: true
       })
       .append({
-        label: gettext('Official'),
+        label: gettext('Chameleon Supported'),
         name: 'project_supported',
         isServer: true,
         singleton: true,
@@ -253,7 +253,7 @@
   function imageProperties(imagesService, statuses) {
     return {
       id: gettext('ID'),
-      project_supported: { label: gettext('Official'), filters: ['yesno'] },
+      project_supported: { label: gettext('Chameleon Supported'), filters: ['yesno'] },
       checksum: gettext('Checksum'),
       members: gettext('Members'),
       min_disk: gettext('Min. Disk'),

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -131,14 +131,15 @@
         persistent: true
       })
       .append({
-        label: gettext('Official'),
+        label: gettext('Chameleon Supported'),
         name: 'project_supported',
         isServer: true,
         singleton: true,
         persistent: true,
+        classes: 'chameleon-supported',
         options: [
-          {label: gettext('Yes'), key: 'true'},
-          {label: gettext('No'), key: 'false'}
+          {label: gettext(''), key: 'true'},
+          {label: gettext(' '), key: 'false'}
         ]
       })
       .append({

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -131,15 +131,14 @@
         persistent: true
       })
       .append({
-        label: gettext('Chameleon Supported'),
+        label: gettext('Official'),
         name: 'project_supported',
         isServer: true,
         singleton: true,
         persistent: true,
-        classes: 'chameleon-supported',
         options: [
-          {label: gettext(''), key: 'true'},
-          {label: gettext(' '), key: 'false'}
+          {label: gettext('Yes'), key: 'true'},
+          {label: gettext('No'), key: 'false'}
         ]
       })
       .append({

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -139,8 +139,8 @@
         singleton: true,
         persistent: true,
         options: [
-          {label: gettext('Yes'), key: 'yes'},
-          {label: gettext('No'), key: 'no'}
+          {label: gettext('Yes'), key: 'Yes'},
+          {label: gettext('No'), key: 'No'}
         ]
       })
       .append({

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -92,10 +92,10 @@
         classes: "word-wrap",
         urlFunction: imagesService.getDetailsPath
       })
-      // .append({
-      //   id: 'project_supported',
-      //   priority: 1
-      // })
+      .append({
+        id: 'project_supported',
+        priority: 1
+      })
       .append({
         id: 'type',
         priority: 1
@@ -130,18 +130,17 @@
         singleton: true,
         persistent: true
       })
-      // filtering by project supported not working yet, and it's not part of the requirements
-      // .append({
-      //   label: gettext('Project Supported'),
-      //   name: 'project_supported',
-      //   isServer: true,
-      //   singleton: true,
-      //   persistent: true,
-      //   options: [
-      //     {label: gettext('True'), key: 'true'},
-      //     {label: gettext('False'), key: 'false'}
-      //   ]
-      // })
+      .append({
+        label: gettext('Official'),
+        name: 'project_supported',
+        isServer: true,
+        singleton: true,
+        persistent: true,
+        options: [
+          {label: gettext('Yes'), key: 'true'},
+          {label: gettext('No'), key: 'false'}
+        ]
+      })
       .append({
         label: gettext('Status'),
         name: 'status',
@@ -254,7 +253,7 @@
   function imageProperties(imagesService, statuses) {
     return {
       id: gettext('ID'),
-      project_supported: gettext('Project Supported'),
+      project_supported: { label: gettext('Official'), filters: ['yesno'] },
       checksum: gettext('Checksum'),
       members: gettext('Members'),
       min_disk: gettext('Min. Disk'),

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -133,6 +133,7 @@
       .append({
         label: gettext('Chameleon Supported'),
         name: 'project_supported',
+        classes: ['chameleon-supported'],
         isServer: true,
         singleton: true,
         persistent: true,

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -133,7 +133,7 @@
       .append({
         label: gettext('Chameleon Supported'),
         name: 'project_supported',
-        classes: ['chameleon-supported'],
+        classes: 'chameleon-supported',
         isServer: true,
         singleton: true,
         persistent: true,

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -254,7 +254,7 @@
   function imageProperties(imagesService, statuses) {
     return {
       id: gettext('ID'),
-      project_supported: { label: gettext('Chameleon Supported'), filters: ['chameleon_logo'] },
+      project_supported: { label: gettext('Official'), filters: ['yesno'] },
       checksum: gettext('Checksum'),
       members: gettext('Members'),
       min_disk: gettext('Min. Disk'),


### PR DESCRIPTION
There is now a column on the images table which denotes whether an image is officially supported by Chameleon. The column can be ordered by whether an image is official, which effectively allows users to filter by official images.

![image](https://user-images.githubusercontent.com/14908880/214408395-e0749b66-7fb0-4d02-8ba9-0116ac833a39.png)