### PR TITLE
Remove unused tabs

### DIFF
--- a/openstack_dashboard/api/rest/nova.py
+++ b/openstack_dashboard/api/rest/nova.py
@@ -365,7 +365,9 @@ class Servers(generic.View):
                 request,
                 request.DATA['name'],
                 request.DATA['source_id'],
-                request.DATA['flavor_id'],
+                # Since we have disabled flavors, we'll hardcode the default
+                # request.DATA['flavor_id'],
+                "baremetal",
                 request.DATA['key_name'],
                 request.DATA['user_data'],
                 request.DATA['security_groups'],

--- a/openstack_dashboard/api/rest/nova.py
+++ b/openstack_dashboard/api/rest/nova.py
@@ -364,7 +364,7 @@ class Servers(generic.View):
         try:
             flavors = api.nova.flavor_list(request)
             flavor_id = flavors[0].id
-        except IndexError:
+        except Exception:
             raise rest_utils.AjaxError(500, "Unable to set default flavor.")
         try:
             args = (

--- a/openstack_dashboard/api/rest/nova.py
+++ b/openstack_dashboard/api/rest/nova.py
@@ -363,7 +363,7 @@ class Servers(generic.View):
         # Since baremetal sites only have one flavor, just grab the ID from the first one
         try:
             flavors = api.nova.flavor_list(request)
-            flavor_id = flavors[0].id
+            flavor_id = next(filter((lambda f: f.name.lower() == "baremetal"), flavors), None).id
         except Exception:
             raise rest_utils.AjaxError(500, "Unable to set default flavor.")
         try:

--- a/openstack_dashboard/api/rest/nova.py
+++ b/openstack_dashboard/api/rest/nova.py
@@ -360,6 +360,12 @@ class Servers(generic.View):
 
         This returns the new server object on success.
         """
+        # Since baremetal sites only have one flavor, just grab the ID from the first one
+        try:
+            flavors = api.nova.flavor_list(request)
+            flavor_id = flavors[0]["id"]
+        except (IndexError, KeyError):
+            raise rest_utils.AjaxError(500, "Unable to set default flavor.")
         try:
             args = (
                 request,
@@ -367,7 +373,7 @@ class Servers(generic.View):
                 request.DATA['source_id'],
                 # Since we have disabled flavors, we'll hardcode the default
                 # request.DATA['flavor_id'],
-                "baremetal",
+                flavor_id,
                 request.DATA['key_name'],
                 request.DATA['user_data'],
                 request.DATA['security_groups'],

--- a/openstack_dashboard/api/rest/nova.py
+++ b/openstack_dashboard/api/rest/nova.py
@@ -363,8 +363,8 @@ class Servers(generic.View):
         # Since baremetal sites only have one flavor, just grab the ID from the first one
         try:
             flavors = api.nova.flavor_list(request)
-            flavor_id = flavors[0]["id"]
-        except (IndexError, KeyError):
+            flavor_id = flavors[0].id
+        except IndexError:
             raise rest_utils.AjaxError(500, "Unable to set default flavor.")
         try:
             args = (

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -68,14 +68,18 @@
           formName: 'launchInstanceNetworkPortForm',
           requiredServiceTypes: ['network']
         },
-        {
-          id: 'secgroups',
-          title: gettext('Security Groups'),
-          templateUrl: basePath + 'security-groups/security-groups.html',
-          helpUrl: basePath + 'security-groups/security-groups.help.html',
-          formName: 'launchInstanceAccessAndSecurityForm',
-          requiredServiceTypes: ['network']
-        },
+        // We remove the security groups tab from the instance creation dialogue because
+        // they do nothing on bare metal, and they confuse users
+        // The commit that introduced this change should not ever be applied to the
+        // KVM branch, as security groups are useful on KVM sites.
+        // {
+        //   id: 'secgroups',
+        //   title: gettext('Security Groups'),
+        //   templateUrl: basePath + 'security-groups/security-groups.html',
+        //   helpUrl: basePath + 'security-groups/security-groups.help.html',
+        //   formName: 'launchInstanceAccessAndSecurityForm',
+        //   requiredServiceTypes: ['network']
+        // },
         {
           id: 'keypair',
           title: gettext('Key Pair'),

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -45,13 +45,17 @@
           helpUrl: basePath + 'source/source.help.html',
           formName: 'launchInstanceSourceForm'
         },
-        {
-          id: 'flavor',
-          title: gettext('Flavor'),
-          templateUrl: basePath + 'flavor/flavor.html',
-          helpUrl: basePath + 'flavor/flavor.help.html',
-          formName: 'launchInstanceFlavorForm'
-        },
+        // We remove the Flavors tab from the instance creation dialogue because
+        // there is only one flavor on baremetal sites: "baremetal."
+        // The commit that introduced this change should not ever be applied to the
+        // KVM branch, as flavors are necessary on KVM sites.
+        // {
+        //   id: 'flavor',
+        //   title: gettext('Flavor'),
+        //   templateUrl: basePath + 'flavor/flavor.html',
+        //   helpUrl: basePath + 'flavor/flavor.help.html',
+        //   formName: 'launchInstanceFlavorForm'
+        // },
         {
           id: 'networks',
           title: gettext('Networks'),

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -98,14 +98,16 @@
           helpUrl: basePath + 'configuration/configuration.help.html',
           formName: 'launchInstanceConfigurationForm'
         },
-        {
-          id: 'servergroups',
-          title: gettext('Server Groups'),
-          templateUrl: basePath + 'server-groups/server-groups.html',
-          helpUrl: basePath + 'server-groups/server-groups.help.html',
-          formName: 'launchInstanceServerGroupsForm',
-          policy: stepPolicy.serverGroups
-        },
+        // We remove server groups from the instance creation dialogue
+        // because they are not used
+        // {
+        //   id: 'servergroups',
+        //   title: gettext('Server Groups'),
+        //   templateUrl: basePath + 'server-groups/server-groups.html',
+        //   helpUrl: basePath + 'server-groups/server-groups.help.html',
+        //   formName: 'launchInstanceServerGroupsForm',
+        //   policy: stepPolicy.serverGroups
+        // },
         {
           id: 'hints',
           title: gettext('Scheduler Hints'),

--- a/openstack_dashboard/enabled/_1110_project_server_groups_panel.py
+++ b/openstack_dashboard/enabled/_1110_project_server_groups_panel.py
@@ -6,5 +6,6 @@ PANEL_DASHBOARD = 'project'
 PANEL_GROUP = 'compute'
 
 # Python panel class of the PANEL to be added.
-ADD_PANEL = ('openstack_dashboard.dashboards.project.server_groups'
-             '.panel.ServerGroups')
+# NOTE: This panel is disabled because server groups are unused
+# ADD_PANEL = ('openstack_dashboard.dashboards.project.server_groups'
+#              '.panel.ServerGroups')

--- a/openstack_dashboard/enabled/_1480_security_groups_panel.py
+++ b/openstack_dashboard/enabled/_1480_security_groups_panel.py
@@ -5,6 +5,6 @@ PANEL_GROUP = 'network'
 PANEL = 'security_groups'
 
 # Security groups only work on KVM sites, so we only load them there
-if settings.CHAMELEON_SITE_ID.startswith("KVM"):
+if not settings.CHAMELEON_IS_BAREMETAL_SITE:
     ADD_PANEL = ('openstack_dashboard.dashboards.project.security_groups'
                  '.panel.SecurityGroups')

--- a/openstack_dashboard/enabled/_1480_security_groups_panel.py
+++ b/openstack_dashboard/enabled/_1480_security_groups_panel.py
@@ -1,6 +1,10 @@
+from django.conf import settings
+
 PANEL_DASHBOARD = 'project'
 PANEL_GROUP = 'network'
 PANEL = 'security_groups'
 
-ADD_PANEL = ('openstack_dashboard.dashboards.project.security_groups'
-             '.panel.SecurityGroups')
+# Security groups only work on KVM sites, so we only load them there
+if settings.CHAMELEON_SITE_ID.startswith("KVM"):
+    ADD_PANEL = ('openstack_dashboard.dashboards.project.security_groups'
+                 '.panel.SecurityGroups')

--- a/openstack_dashboard/enabled/_1480_security_groups_panel.py
+++ b/openstack_dashboard/enabled/_1480_security_groups_panel.py
@@ -4,7 +4,7 @@ PANEL_DASHBOARD = 'project'
 PANEL_GROUP = 'network'
 PANEL = 'security_groups'
 
-# Security groups only work on KVM sites, so we only load them there
+# Security groups don't work on bare metal sites, so we don't load them there
 if not settings.CHAMELEON_IS_BAREMETAL_SITE:
     ADD_PANEL = ('openstack_dashboard.dashboards.project.security_groups'
                  '.panel.SecurityGroups')

--- a/openstack_dashboard/enabled/_1480_security_groups_panel.py
+++ b/openstack_dashboard/enabled/_1480_security_groups_panel.py
@@ -5,6 +5,5 @@ PANEL_GROUP = 'network'
 PANEL = 'security_groups'
 
 # Security groups don't work on bare metal sites, so we don't load them there
-if not settings.CHAMELEON_IS_BAREMETAL_SITE:
-    ADD_PANEL = ('openstack_dashboard.dashboards.project.security_groups'
-                 '.panel.SecurityGroups')
+# ADD_PANEL = ('openstack_dashboard.dashboards.project.security_groups'
+#              '.panel.SecurityGroups')


### PR DESCRIPTION
This patch removes several tabs from the main dashboard menu and the instance creation modal dialogue. These tabs were either completely unsupported on baremetal sites or simply unused. 

The tabs removed:

* Security Groups
    * Removed from dashboard and instance creation dialogue
* Flavors
    * Removed from instance creation dialogue
* Server Groups
    * Removed from dashboard and instance creation dialogue

Tabs removed from the main dashboard simply don't execute the code which registers them to that dashboard. 

The instance creation modal dialogue unfortunately only exists in the front end, so the code which registers the undesired tabs is simply commented out. 

A new setting, `CHAMELEON_IS_BAREMETAL_SITE` has been introduced, and there is a related PR for https://github.com/ChameleonCloud/chi-in-a-box/pull/250 has been submitted to configure this. 

Since the instance creation modal dialogue only exists in the front-end, it was not obvious if it was possible to transfer the context of this new setting to the dialogue to allow for conditional registration of the undesired tabs. Instead, the tabs are simply commented out. Because of this, these particular commits should not be deployed on KVM.

