### PR TITLE
Move uncommon tabs to advanced section

### DIFF
--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -73,7 +73,7 @@
     viewModel.isSubmitting = false;
 
     $scope.showAdvancedButton = function() {
-      return viewModel.advanced.showButton && viewModel.advanced.showTabs;
+      return viewModel.advanced.showButton && !viewModel.advanced.showTabs;
     };
     $scope.hideAdvancedButton = function() {
       return viewModel.advanced.showButton && viewModel.advanced.showTabs;

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -57,6 +57,7 @@
 
     $scope.switchTo = switchTo;
     $scope.showError = showError;
+    $scope.toggleAdvanced = toggleAdvanced;
     ctrl.toggleHelpBtn = toggleHelpBtn;
     ctrl.onInitSuccess = onInitSuccess;
     ctrl.onInitError = onInitError;
@@ -67,6 +68,7 @@
     viewModel.btnIcon = $scope.workflow.btnIcon || {};
     viewModel.showSpinner = false;
     viewModel.hasError = false;
+    viewModel.showAdvanced = false;
     viewModel.onClickFinishBtn = onClickFinishBtn;
     viewModel.isSubmitting = false;
 
@@ -96,6 +98,10 @@
       $scope.currentIndex = index;
       $scope.openHelp = false;
       /*eslint-enable angular/controller-as*/
+    }
+
+    function toggleAdvanced() {
+      $scope.showAdvanced = !$scope.showAdvanced;
     }
 
     function showError(errorMessage) {

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -239,7 +239,7 @@
       viewModel.ready = stepReadyPromises.length === 0;
       return $q.all(stepReadyPromises).finally(function() {
         $scope.steps = $scope.steps.filter(function(step) {
-          return $scope.shouldShowStep(step);
+          return step.ready;
         });
       });
     }

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -79,6 +79,7 @@
       return viewModel.advanced.showButton && viewModel.advanced.showTabs;
     };
     $scope.shouldShowStep = function(step) {
+      console.log(`STEP ${step} VIEW ${viewModel.advanced.showTabs}`);
       if (step.advanced) {
         return step.ready && viewModel.advanced.showTabs;
       } else {

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -68,6 +68,7 @@
     viewModel.btnIcon = $scope.workflow.btnIcon || {};
     viewModel.showSpinner = false;
     viewModel.hasError = false;
+    viewModel.hasAdvanced = false;
     viewModel.showAdvanced = false;
     viewModel.onClickFinishBtn = onClickFinishBtn;
     viewModel.isSubmitting = false;

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -52,6 +52,8 @@
     var steps = $scope.steps = $scope.workflow.steps || [];
     $scope.wizardForm = {};
 
+    $scope.advanced = extend({showButton: false, showTabs: true}, $scope.workflow.advanced);
+
     // a place to keep each step's captured data, named for their step.formName
     $scope.stepModels = {};
 
@@ -68,20 +70,19 @@
     viewModel.btnIcon = $scope.workflow.btnIcon || {};
     viewModel.showSpinner = false;
     viewModel.hasError = false;
-    viewModel.advanced = extend({showButton: false, showTabs: true}, $scope.workflow.advanced);
     viewModel.onClickFinishBtn = onClickFinishBtn;
     viewModel.isSubmitting = false;
 
     $scope.showAdvancedButton = function() {
-      return viewModel.advanced.showButton && !viewModel.advanced.showTabs;
+      return $scope.advanced.showButton && !$scope.advanced.showTabs;
     };
     $scope.hideAdvancedButton = function() {
-      return viewModel.advanced.showButton && viewModel.advanced.showTabs;
+      return $scope.advanced.showButton && $scope.advanced.showTabs;
     };
     $scope.shouldShowStep = function(step) {
       if (step.isAdvanced) {
-        console.log(`STEP ${JSON.stringify(step)} VIEW ${viewModel.advanced.showTabs}`);
-        return step.ready && viewModel.advanced.showTabs;
+        console.log(`STEP ${JSON.stringify(step)} VIEW ${$scope.advanced.showTabs}`);
+        return step.ready && $scope.advanced.showTabs;
       } else {
         return step.ready;
       }
@@ -116,7 +117,7 @@
     }
 
     function toggleAdvanced() {
-      viewModel.advanced.showTabs = !viewModel.advanced.showTabs;
+      $scope.advanced.showTabs = !$scope.advanced.showTabs;
     }
 
     function showError(errorMessage) {

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -68,8 +68,7 @@
     viewModel.btnIcon = $scope.workflow.btnIcon || {};
     viewModel.showSpinner = false;
     viewModel.hasError = false;
-    viewModel.hasAdvanced = false;
-    viewModel.showAdvanced = false;
+    viewModel.advanced = extend({}, wizardLabels, $scope.workflow.advanced);
     viewModel.onClickFinishBtn = onClickFinishBtn;
     viewModel.isSubmitting = false;
 
@@ -102,7 +101,7 @@
     }
 
     function toggleAdvanced() {
-      $scope.showAdvanced = !$scope.showAdvanced;
+      viewModel.advanced.showTabs = !viewModel.advanced.showTabs;
     }
 
     function showError(errorMessage) {

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -79,7 +79,11 @@
       return viewModel.advanced.showButton && viewModel.advanced.showTabs;
     };
     $scope.shouldShowStep = function(step) {
-
+      if (step.advanced) {
+        return step.ready && viewModel.advanced.showTabs;
+      } else {
+        return step.ready;
+      }
     };
 
     $scope.initPromise.then(onInitSuccess, onInitError);

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -73,10 +73,10 @@
     viewModel.isSubmitting = false;
 
     $scope.showAdvancedButton = function() {
-      return $scope.viewModel.advanced.showButton && $scope.viewModel.advanced.showTabs;
+      return viewModel.advanced.showButton && $scope.viewModel.advanced.showTabs;
     };
     $scope.hideAdvancedButton = function() {
-      return $scope.viewModel.advanced.showButton && $scope.viewModel.advanced.showTabs;
+      return viewModel.advanced.showButton && $scope.viewModel.advanced.showTabs;
     };
 
     $scope.initPromise.then(onInitSuccess, onInitError);

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -68,7 +68,7 @@
     viewModel.btnIcon = $scope.workflow.btnIcon || {};
     viewModel.showSpinner = false;
     viewModel.hasError = false;
-    viewModel.advanced = extend({}, wizardLabels, $scope.workflow.advanced);
+    viewModel.advanced = extend({}, {showButton: false, showTabs: true}, $scope.workflow.advanced);
     viewModel.onClickFinishBtn = onClickFinishBtn;
     viewModel.isSubmitting = false;
 

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -73,12 +73,10 @@
     viewModel.isSubmitting = false;
 
     $scope.showAdvancedButton = function() {
-      console.log(viewModel);
-      console.log(viewModel.advanced);
-      return viewModel.advanced.showButton && $scope.viewModel.advanced.showTabs;
+      return viewModel.advanced.showButton && viewModel.advanced.showTabs;
     };
     $scope.hideAdvancedButton = function() {
-      return viewModel.advanced.showButton && $scope.viewModel.advanced.showTabs;
+      return viewModel.advanced.showButton && viewModel.advanced.showTabs;
     };
 
     $scope.initPromise.then(onInitSuccess, onInitError);

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -79,8 +79,7 @@
       return viewModel.advanced.showButton && viewModel.advanced.showTabs;
     };
     $scope.shouldShowStep = function(step) {
-      console.log(`STEP ${JSON.stringify(step)} VIEW ${JSON.stringify(viewModel.advanced.showTabs)}`);
-      if (step.advanced) {
+      if (step.isAdvanced) {
         return step.ready && viewModel.advanced.showTabs;
       } else {
         return step.ready;

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -79,7 +79,7 @@
       return viewModel.advanced.showButton && viewModel.advanced.showTabs;
     };
     $scope.shouldShowStep = function(step) {
-      console.log(`STEP ${step} VIEW ${viewModel.advanced.showTabs}`);
+      console.log(`STEP ${step} VIEW ${JSON.stringify(viewModel.advanced.showTabs)}`);
       if (step.advanced) {
         return step.ready && viewModel.advanced.showTabs;
       } else {

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -68,7 +68,7 @@
     viewModel.btnIcon = $scope.workflow.btnIcon || {};
     viewModel.showSpinner = false;
     viewModel.hasError = false;
-    viewModel.advanced = extend({}, {showButton: false, showTabs: true}, $scope.workflow.advanced);
+    viewModel.advanced = extend({showButton: false, showTabs: true}, $scope.workflow.advanced);
     viewModel.onClickFinishBtn = onClickFinishBtn;
     viewModel.isSubmitting = false;
 
@@ -219,15 +219,9 @@
         step.ready = !step.checkReadiness;
 
         if (step.checkReadiness) {
-          var promise;
-          if (step.checkReadiness.length === 1) {
-            promise = step.checkReadiness($scope);
-          } else {
-            promise = step.checkReadiness();
-          }
+          var promise = step.checkReadiness();
           stepReadyPromises.push(promise);
           promise.then(function(isReady) {
-            console.log(`STEP ${JSON.stringify(step)} IS READY ${isReady}`);
             step.ready = isReady;
           });
         }
@@ -236,7 +230,11 @@
       viewModel.ready = stepReadyPromises.length === 0;
       return $q.all(stepReadyPromises).finally(function() {
         $scope.steps = $scope.steps.filter(function(step) {
-          return step.ready;
+          if (step.isAdvanced) {
+            return step.ready && step.showTabs;
+          } else {
+            return step.ready;
+          }
         });
       });
     }

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -78,6 +78,9 @@
     $scope.hideAdvancedButton = function() {
       return viewModel.advanced.showButton && viewModel.advanced.showTabs;
     };
+    $scope.shouldShowStep = function(step) {
+
+    };
 
     $scope.initPromise.then(onInitSuccess, onInitError);
 
@@ -230,11 +233,7 @@
       viewModel.ready = stepReadyPromises.length === 0;
       return $q.all(stepReadyPromises).finally(function() {
         $scope.steps = $scope.steps.filter(function(step) {
-          if (step.isAdvanced) {
-            return step.ready && step.showTabs;
-          } else {
-            return step.ready;
-          }
+          $scope.shouldShowStep(step);
         });
       });
     }

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -62,13 +62,6 @@
     ctrl.onInitSuccess = onInitSuccess;
     ctrl.onInitError = onInitError;
 
-    $scope.showAdvancedButton = function() {
-      return $scope.viewModel.advanced.showButton && $scope.viewModel.advanced.showTabs;
-    };
-    $scope.hideAdvancedButton = function() {
-      return $scope.viewModel.advanced.showButton && $scope.viewModel.advanced.showTabs;
-    };
-
     /*eslint-enable angular/controller-as */
 
     viewModel.btnText = extend({}, wizardLabels, $scope.workflow.btnText);
@@ -78,6 +71,13 @@
     viewModel.advanced = extend({}, wizardLabels, $scope.workflow.advanced);
     viewModel.onClickFinishBtn = onClickFinishBtn;
     viewModel.isSubmitting = false;
+
+    $scope.showAdvancedButton = function() {
+      return $scope.viewModel.advanced.showButton && $scope.viewModel.advanced.showTabs;
+    };
+    $scope.hideAdvancedButton = function() {
+      return $scope.viewModel.advanced.showButton && $scope.viewModel.advanced.showTabs;
+    };
 
     $scope.initPromise.then(onInitSuccess, onInitError);
 

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -237,7 +237,7 @@
       viewModel.ready = stepReadyPromises.length === 0;
       return $q.all(stepReadyPromises).finally(function() {
         $scope.steps = $scope.steps.filter(function(step) {
-          $scope.shouldShowStep(step);
+          return $scope.shouldShowStep(step);
         });
       });
     }

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -81,7 +81,6 @@
     };
     $scope.shouldShowStep = function(step) {
       if (step.isAdvanced) {
-        console.log(`STEP ${JSON.stringify(step)} VIEW ${$scope.advanced.showTabs}`);
         return step.ready && $scope.advanced.showTabs;
       } else {
         return step.ready;
@@ -114,6 +113,9 @@
       $scope.currentIndex = index;
       $scope.openHelp = false;
       /*eslint-enable angular/controller-as*/
+      if (steps[index].isAdvanced) {
+        $scope.advanced.showTabs = true;
+      }
     }
 
     function toggleAdvanced() {

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -79,7 +79,7 @@
       return viewModel.advanced.showButton && viewModel.advanced.showTabs;
     };
     $scope.shouldShowStep = function(step) {
-      console.log(`STEP ${step} VIEW ${JSON.stringify(viewModel.advanced.showTabs)}`);
+      console.log(`STEP ${JSON.stringify(step)} VIEW ${JSON.stringify(viewModel.advanced.showTabs)}`);
       if (step.advanced) {
         return step.ready && viewModel.advanced.showTabs;
       } else {

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -73,6 +73,8 @@
     viewModel.isSubmitting = false;
 
     $scope.showAdvancedButton = function() {
+      console.log(viewModel);
+      console.log(viewModel.advanced);
       return viewModel.advanced.showButton && $scope.viewModel.advanced.showTabs;
     };
     $scope.hideAdvancedButton = function() {

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -62,6 +62,13 @@
     ctrl.onInitSuccess = onInitSuccess;
     ctrl.onInitError = onInitError;
 
+    $scope.showAdvancedButton = function() {
+      return $scope.viewModel.advanced.showButton && $scope.viewModel.advanced.showTabs;
+    };
+    $scope.hideAdvancedButton = function() {
+      return $scope.viewModel.advanced.showButton && $scope.viewModel.advanced.showTabs;
+    };
+
     /*eslint-enable angular/controller-as */
 
     viewModel.btnText = extend({}, wizardLabels, $scope.workflow.btnText);

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -212,7 +212,12 @@
         step.ready = !step.checkReadiness;
 
         if (step.checkReadiness) {
-          var promise = step.checkReadiness();
+          var promise;
+          if (step.checkReadiness.length === 1) {
+            promise = step.checkReadiness($scope);
+          } else {
+            promise = step.checkReadiness();
+          }
           stepReadyPromises.push(promise);
           promise.then(function(isReady) {
             step.ready = isReady;

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -227,6 +227,7 @@
           }
           stepReadyPromises.push(promise);
           promise.then(function(isReady) {
+            console.log(`STEP ${JSON.stringify(step)} IS READY ${isReady}`);
             step.ready = isReady;
           });
         }

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -80,6 +80,7 @@
     };
     $scope.shouldShowStep = function(step) {
       if (step.isAdvanced) {
+        console.log(`STEP ${JSON.stringify(step)} VIEW ${viewModel.advanced.showTabs}`);
         return step.ready && viewModel.advanced.showTabs;
       } else {
         return step.ready;

--- a/horizon/static/framework/widgets/wizard/wizard.html
+++ b/horizon/static/framework/widgets/wizard/wizard.html
@@ -66,9 +66,9 @@
       <span ng-bind="::viewModel.btnText.cancel"></span>
     </button>
     <button type="button" class="btn btn-default pull-left"
-            ng-click="toggleAdvanced()" ng-show="::viewModel.advanced.showButton && !::viewModel.advanced.showTabs">Show Advanced</button>
+            ng-click="toggleAdvanced()" ng-show="showAdvancedButton()">Show Advanced</button>
     <button type="button" class="btn btn-default pull-left"
-            ng-click="toggleAdvanced()" ng-show="::viewModel.advanced.showButton && ::viewModel.advanced.showTabs">Hide Advanced</button>
+            ng-click="toggleAdvanced()" ng-show="hideAdvancedButton()">Hide Advanced</button>
 
     <button type="button" class="btn btn-default back"
       ng-click="switchTo(currentIndex - 1)"

--- a/horizon/static/framework/widgets/wizard/wizard.html
+++ b/horizon/static/framework/widgets/wizard/wizard.html
@@ -66,9 +66,9 @@
       <span ng-bind="::viewModel.btnText.cancel"></span>
     </button>
     <button type="button" class="btn btn-default pull-left"
-            ng-click="toggleAdvanced()" ng-show="showAdvancedButton()">Show Advanced</button>
+            ng-click="toggleAdvanced()" ng-show="true">Show Advanced</button>
     <button type="button" class="btn btn-default pull-left"
-            ng-click="toggleAdvanced()" ng-show="hideAdvancedButton()">Hide Advanced</button>
+            ng-click="toggleAdvanced()" ng-show="true">Hide Advanced</button>
 
     <button type="button" class="btn btn-default back"
       ng-click="switchTo(currentIndex - 1)"

--- a/horizon/static/framework/widgets/wizard/wizard.html
+++ b/horizon/static/framework/widgets/wizard/wizard.html
@@ -66,9 +66,9 @@
       <span ng-bind="::viewModel.btnText.cancel"></span>
     </button>
     <button type="button" class="btn btn-default pull-left"
-            ng-click="toggleAdvanced()" ng-show="!showAdvanced">Show Advanced</button>
+            ng-click="toggleAdvanced()" ng-show="::viewModel.hasAdvanced && !showAdvanced">Show Advanced</button>
     <button type="button" class="btn btn-default pull-left"
-            ng-click="toggleAdvanced()" ng-show="showAdvanced">Hide Advanced</button>
+            ng-click="toggleAdvanced()" ng-show="::viewModel.hasAdvanced && showAdvanced">Hide Advanced</button>
 
     <button type="button" class="btn btn-default back"
       ng-click="switchTo(currentIndex - 1)"

--- a/horizon/static/framework/widgets/wizard/wizard.html
+++ b/horizon/static/framework/widgets/wizard/wizard.html
@@ -66,9 +66,9 @@
       <span ng-bind="::viewModel.btnText.cancel"></span>
     </button>
     <button type="button" class="btn btn-default pull-left"
-            ng-click="toggleAdvanced()" ng-show="::viewModel.hasAdvanced && !showAdvanced">Show Advanced</button>
+            ng-click="toggleAdvanced()" ng-show="::viewModel.advanced.showButton && !::viewModel.advanced.showTabs">Show Advanced</button>
     <button type="button" class="btn btn-default pull-left"
-            ng-click="toggleAdvanced()" ng-show="::viewModel.hasAdvanced && showAdvanced">Hide Advanced</button>
+            ng-click="toggleAdvanced()" ng-show="::viewModel.advanced.showButton && ::viewModel.advanced.showTabs">Hide Advanced</button>
 
     <button type="button" class="btn btn-default back"
       ng-click="switchTo(currentIndex - 1)"

--- a/horizon/static/framework/widgets/wizard/wizard.html
+++ b/horizon/static/framework/widgets/wizard/wizard.html
@@ -65,6 +65,10 @@
       <span ng-class="::viewModel.btnIcon.cancel||'fa fa-close'"></span>
       <span ng-bind="::viewModel.btnText.cancel"></span>
     </button>
+    <button type="button" class="btn btn-default pull-left"
+            ng-click="toggleAdvanced()" ng-show="!showAdvanced">Show Advanced</button>
+    <button type="button" class="btn btn-default pull-left"
+            ng-click="toggleAdvanced()" ng-show="showAdvanced">Hide Advanced</button>
 
     <button type="button" class="btn btn-default back"
       ng-click="switchTo(currentIndex - 1)"

--- a/horizon/static/framework/widgets/wizard/wizard.html
+++ b/horizon/static/framework/widgets/wizard/wizard.html
@@ -68,7 +68,7 @@
     <button type="button" class="btn btn-default pull-left"
             ng-click="toggleAdvanced()" ng-show="showAdvancedButton()">Show Advanced</button>
     <button type="button" class="btn btn-default pull-left"
-            ng-click="toggleAdvanced()" ng-show="showAdvancedButton()">Hide Advanced</button>
+            ng-click="toggleAdvanced()" ng-show="hideAdvancedButton()">Hide Advanced</button>
 
     <button type="button" class="btn btn-default back"
       ng-click="switchTo(currentIndex - 1)"

--- a/horizon/static/framework/widgets/wizard/wizard.html
+++ b/horizon/static/framework/widgets/wizard/wizard.html
@@ -66,9 +66,9 @@
       <span ng-bind="::viewModel.btnText.cancel"></span>
     </button>
     <button type="button" class="btn btn-default pull-left"
-            ng-click="toggleAdvanced()" ng-show="true">Show Advanced</button>
+            ng-click="toggleAdvanced()" ng-show="showAdvancedButton()">Show Advanced</button>
     <button type="button" class="btn btn-default pull-left"
-            ng-click="toggleAdvanced()" ng-show="true">Hide Advanced</button>
+            ng-click="toggleAdvanced()" ng-show="showAdvancedButton()">Hide Advanced</button>
 
     <button type="button" class="btn btn-default back"
       ng-click="switchTo(currentIndex - 1)"

--- a/horizon/static/framework/widgets/wizard/wizard.html
+++ b/horizon/static/framework/widgets/wizard/wizard.html
@@ -27,7 +27,7 @@
                 ng-class="{'active': currentIndex===$index}"
                 ng-click="switchTo($index)"
                 ng-repeat="step in steps"
-                ng-show="step.ready">
+                ng-show="shouldShowStep(step)">
               <a href="#">
                 <span ng-bind="::step.title"></span>
                 <span class="hz-icon-required fa fa-asterisk"

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -21,13 +21,21 @@
     .factory('horizon.dashboard.project.workflow.launch-instance.workflow', launchInstanceWorkflow);
 
   launchInstanceWorkflow.$inject = [
-    "$scope",
+    '$q',
+    '$scope',
     'horizon.dashboard.project.workflow.launch-instance.basePath',
     'horizon.dashboard.project.workflow.launch-instance.step-policy',
     'horizon.app.core.workflow.factory'
   ];
 
-  function launchInstanceWorkflow($scope, basePath, stepPolicy, dashboardWorkflow) {
+  function launchInstanceWorkflow($q, $scope, basePath, stepPolicy, dashboardWorkflow) {
+    const showTabsPromise = function() {
+      const deferred = $q.defer();
+      const advancedTabs = $scope.viewModel.advancedTabs;
+      deferred.resolve(() => advancedTabs.showTabs);
+      return deferred.promise;
+    };
+
     return dashboardWorkflow({
       title: gettext('Launch Instance'),
 
@@ -98,7 +106,7 @@
           templateUrl: basePath + 'configuration/configuration.html',
           helpUrl: basePath + 'configuration/configuration.help.html',
           formName: 'launchInstanceConfigurationForm',
-          checkReadiness: function() { return $scope.viewModel.advanced.showTabs; }
+          checkReadiness: showTabsPromise
         },
         {
           id: 'servergroups',
@@ -107,7 +115,7 @@
           helpUrl: basePath + 'server-groups/server-groups.help.html',
           formName: 'launchInstanceServerGroupsForm',
           policy: stepPolicy.serverGroups,
-          checkReadiness: function() { return $scope.viewModel.advanced.showTabs; }
+          checkReadiness: showTabsPromise
         },
         {
           id: 'hints',
@@ -117,7 +125,7 @@
           formName: 'launchInstanceSchedulerHintsForm',
           policy: stepPolicy.schedulerHints,
           setting: 'LAUNCH_INSTANCE_DEFAULTS.enable_scheduler_hints',
-          checkReadiness: function() { return $scope.viewModel.advanced.showTabs; }
+          checkReadiness: showTabsPromise
         },
         {
           id: 'metadata',
@@ -125,7 +133,7 @@
           templateUrl: basePath + 'metadata/metadata.html',
           helpUrl: basePath + 'metadata/metadata.help.html',
           formName: 'launchInstanceMetadataForm',
-          checkReadiness: function() { return $scope.viewModel.advanced.showTabs; }
+          checkReadiness: showTabsPromise
         }
       ],
 

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -31,8 +31,10 @@
   function launchInstanceWorkflow($q, $scope, basePath, stepPolicy, dashboardWorkflow) {
     const showTabsPromise = function() {
       const deferred = $q.defer();
-      const advancedTabs = $scope.viewModel.advancedTabs;
-      deferred.resolve(() => advancedTabs.showTabs);
+      deferred.resolve(() => {
+        const advancedTabs = $scope.viewModel.advancedTabs;
+        return advancedTabs.showTabs;
+      });
       return deferred.promise;
     };
 

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -29,11 +29,7 @@
 
   function launchInstanceWorkflow($q, basePath, stepPolicy, dashboardWorkflow) {
     const showTabsPromise = function ($scope) {
-      const deferred = $q.defer();
-      deferred.resolve(() => {
-        return $scope.viewModel.advanced.showTabs;
-      });
-      return deferred.promise;
+      return $q.defer().promise.then(() => $scope.viewModel.advanced.showTabs);
     };
 
     return dashboardWorkflow({

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -21,12 +21,13 @@
     .factory('horizon.dashboard.project.workflow.launch-instance.workflow', launchInstanceWorkflow);
 
   launchInstanceWorkflow.$inject = [
+    "$scope",
     'horizon.dashboard.project.workflow.launch-instance.basePath',
     'horizon.dashboard.project.workflow.launch-instance.step-policy',
     'horizon.app.core.workflow.factory'
   ];
 
-  function launchInstanceWorkflow(basePath, stepPolicy, dashboardWorkflow) {
+  function launchInstanceWorkflow($scope, basePath, stepPolicy, dashboardWorkflow) {
     return dashboardWorkflow({
       title: gettext('Launch Instance'),
 
@@ -96,7 +97,8 @@
           title: gettext('Configuration'),
           templateUrl: basePath + 'configuration/configuration.html',
           helpUrl: basePath + 'configuration/configuration.help.html',
-          formName: 'launchInstanceConfigurationForm'
+          formName: 'launchInstanceConfigurationForm',
+          checkReadiness: function() { return $scope.viewModel.advanced.showTabs; }
         },
         {
           id: 'servergroups',
@@ -104,7 +106,8 @@
           templateUrl: basePath + 'server-groups/server-groups.html',
           helpUrl: basePath + 'server-groups/server-groups.help.html',
           formName: 'launchInstanceServerGroupsForm',
-          policy: stepPolicy.serverGroups
+          policy: stepPolicy.serverGroups,
+          checkReadiness: function() { return $scope.viewModel.advanced.showTabs; }
         },
         {
           id: 'hints',
@@ -113,14 +116,16 @@
           helpUrl: basePath + 'scheduler-hints/scheduler-hints.help.html',
           formName: 'launchInstanceSchedulerHintsForm',
           policy: stepPolicy.schedulerHints,
-          setting: 'LAUNCH_INSTANCE_DEFAULTS.enable_scheduler_hints'
+          setting: 'LAUNCH_INSTANCE_DEFAULTS.enable_scheduler_hints',
+          checkReadiness: function() { return $scope.viewModel.advanced.showTabs; }
         },
         {
           id: 'metadata',
           title: gettext('Metadata'),
           templateUrl: basePath + 'metadata/metadata.html',
           helpUrl: basePath + 'metadata/metadata.help.html',
-          formName: 'launchInstanceMetadataForm'
+          formName: 'launchInstanceMetadataForm',
+          checkReadiness: function() { return $scope.viewModel.advanced.showTabs; }
         }
       ],
 
@@ -132,7 +137,11 @@
         finish: 'fa-cloud-upload'
       },
 
-      hasAdvanced: true
+      advancedTabs: {
+        showButton: true,
+        showTabs: false,
+        hasAdvancedTabs: true
+      }
     });
   }
 

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -130,7 +130,9 @@
 
       btnIcon: {
         finish: 'fa-cloud-upload'
-      }
+      },
+
+      hasAdvanced: true
     });
   }
 

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -21,13 +21,12 @@
     .factory('horizon.dashboard.project.workflow.launch-instance.workflow', launchInstanceWorkflow);
 
   launchInstanceWorkflow.$inject = [
-    '$q',
     'horizon.dashboard.project.workflow.launch-instance.basePath',
     'horizon.dashboard.project.workflow.launch-instance.step-policy',
     'horizon.app.core.workflow.factory'
   ];
 
-  function launchInstanceWorkflow($q, basePath, stepPolicy, dashboardWorkflow) {
+  function launchInstanceWorkflow(basePath, stepPolicy, dashboardWorkflow) {
     return dashboardWorkflow({
       title: gettext('Launch Instance'),
 

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -22,18 +22,16 @@
 
   launchInstanceWorkflow.$inject = [
     '$q',
-    '$scope',
     'horizon.dashboard.project.workflow.launch-instance.basePath',
     'horizon.dashboard.project.workflow.launch-instance.step-policy',
     'horizon.app.core.workflow.factory'
   ];
 
-  function launchInstanceWorkflow($q, $scope, basePath, stepPolicy, dashboardWorkflow) {
-    const showTabsPromise = function() {
+  function launchInstanceWorkflow($q, basePath, stepPolicy, dashboardWorkflow) {
+    const showTabsPromise = function ($scope) {
       const deferred = $q.defer();
       deferred.resolve(() => {
-        const advancedTabs = $scope.viewModel.advancedTabs;
-        return advancedTabs.showTabs;
+        return $scope.viewModel.advanced.showTabs;
       });
       return deferred.promise;
     };
@@ -147,7 +145,7 @@
         finish: 'fa-cloud-upload'
       },
 
-      advancedTabs: {
+      advanced: {
         showButton: true,
         showTabs: false,
         hasAdvancedTabs: true

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -148,7 +148,6 @@
       advanced: {
         showButton: true,
         showTabs: false,
-        hasAdvancedTabs: true
       }
     });
   }

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -28,12 +28,6 @@
   ];
 
   function launchInstanceWorkflow($q, basePath, stepPolicy, dashboardWorkflow) {
-    const showTabsPromise = function ($scope) {
-      return new Promise(function (resolve, reject) {
-        resolve($scope.viewModel.advanced.showTabs);
-      });
-    };
-
     return dashboardWorkflow({
       title: gettext('Launch Instance'),
 

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -29,8 +29,10 @@
 
   function launchInstanceWorkflow($q, basePath, stepPolicy, dashboardWorkflow) {
     const showTabsPromise = function ($scope) {
-      console.log("Foo!");
-      return new Promise((resolve, reject) => resolve($scope.viewModel.advanced.showTabs));
+      return new Promise(function (resolve, reject) {
+        console.log("Foo!!");
+        resolve($scope.viewModel.advanced.showTabs);
+      });
     };
 
     return dashboardWorkflow({

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -29,6 +29,7 @@
 
   function launchInstanceWorkflow($q, basePath, stepPolicy, dashboardWorkflow) {
     const showTabsPromise = function ($scope) {
+      console.log("Foo!");
       return new Promise((resolve, reject) => resolve($scope.viewModel.advanced.showTabs));
     };
 

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -30,7 +30,6 @@
   function launchInstanceWorkflow($q, basePath, stepPolicy, dashboardWorkflow) {
     const showTabsPromise = function ($scope) {
       return new Promise(function (resolve, reject) {
-        console.log("Foo!!");
         resolve($scope.viewModel.advanced.showTabs);
       });
     };

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -29,7 +29,7 @@
 
   function launchInstanceWorkflow($q, basePath, stepPolicy, dashboardWorkflow) {
     const showTabsPromise = function ($scope) {
-      return $q.defer().promise.then(() => $scope.viewModel.advanced.showTabs);
+      return new Promise((resolve, reject) => resolve($scope.viewModel.advanced.showTabs));
     };
 
     return dashboardWorkflow({

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -104,7 +104,7 @@
           templateUrl: basePath + 'configuration/configuration.html',
           helpUrl: basePath + 'configuration/configuration.help.html',
           formName: 'launchInstanceConfigurationForm',
-          checkReadiness: showTabsPromise
+          isAdvanced: true,
         },
         {
           id: 'servergroups',
@@ -113,7 +113,7 @@
           helpUrl: basePath + 'server-groups/server-groups.help.html',
           formName: 'launchInstanceServerGroupsForm',
           policy: stepPolicy.serverGroups,
-          checkReadiness: showTabsPromise
+          isAdvanced: true,
         },
         {
           id: 'hints',
@@ -123,7 +123,7 @@
           formName: 'launchInstanceSchedulerHintsForm',
           policy: stepPolicy.schedulerHints,
           setting: 'LAUNCH_INSTANCE_DEFAULTS.enable_scheduler_hints',
-          checkReadiness: showTabsPromise
+          isAdvanced: true,
         },
         {
           id: 'metadata',
@@ -131,7 +131,7 @@
           templateUrl: basePath + 'metadata/metadata.html',
           helpUrl: basePath + 'metadata/metadata.help.html',
           formName: 'launchInstanceMetadataForm',
-          checkReadiness: showTabsPromise
+          isAdvanced: true,
         }
       ],
 

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -98,16 +98,14 @@
           helpUrl: basePath + 'configuration/configuration.help.html',
           formName: 'launchInstanceConfigurationForm'
         },
-        // We remove server groups from the instance creation dialogue
-        // because they are not used
-        // {
-        //   id: 'servergroups',
-        //   title: gettext('Server Groups'),
-        //   templateUrl: basePath + 'server-groups/server-groups.html',
-        //   helpUrl: basePath + 'server-groups/server-groups.help.html',
-        //   formName: 'launchInstanceServerGroupsForm',
-        //   policy: stepPolicy.serverGroups
-        // },
+        {
+          id: 'servergroups',
+          title: gettext('Server Groups'),
+          templateUrl: basePath + 'server-groups/server-groups.html',
+          helpUrl: basePath + 'server-groups/server-groups.help.html',
+          formName: 'launchInstanceServerGroupsForm',
+          policy: stepPolicy.serverGroups
+        },
         {
           id: 'hints',
           title: gettext('Scheduler Hints'),

--- a/openstack_dashboard/settings.py
+++ b/openstack_dashboard/settings.py
@@ -138,7 +138,7 @@ COMPRESS_CSS_FILTERS = (
     'compressor.filters.css_default.CssAbsoluteFilter',
 )
 
-COMPRESS_ENABLED = True
+COMPRESS_ENABLED = False
 COMPRESS_OUTPUT_DIR = 'dashboard'
 COMPRESS_CSS_HASHING_METHOD = 'hash'
 COMPRESS_PARSER = 'compressor.parser.HtmlParser'

--- a/openstack_dashboard/settings.py
+++ b/openstack_dashboard/settings.py
@@ -138,7 +138,7 @@ COMPRESS_CSS_FILTERS = (
     'compressor.filters.css_default.CssAbsoluteFilter',
 )
 
-COMPRESS_ENABLED = False
+COMPRESS_ENABLED = True
 COMPRESS_OUTPUT_DIR = 'dashboard'
 COMPRESS_CSS_HASHING_METHOD = 'hash'
 COMPRESS_PARSER = 'compressor.parser.HtmlParser'


### PR DESCRIPTION
A little jank, but managed to get it to work! Behavior is essentially:

* Advanced tabs are always hidden when the workflow is launched
* Clicking the "Show Advanced" button does the following:
    * Changes the button to "Hide Advanced"
    * Makes advanced tabs appear
* Clicking the "Hide Advanced" advanced button does the following:
    * Changes the button to "Show Advanced"
    * Makes the advanced tabs disappear
* Using the "Next" or "Back" buttons to scroll to an advanced tab does the following:
    * Causes all the advanced tabs to appear
    * Changes the button to "Hide Advanced"
    * The advanced tabs will only disappear again if you click "Hide Advanced"
* If you hide advanced tabs while an advanced tab is selected:
    * The tab will remain selected
    * All the advanced tabs will be hidden on the sidebar

Currently deployed at https://dev.uc.chameleoncloud.org 
