### PR TITLE
fix quota display when only one quota is shown

### DIFF
--- a/horizon/templates/horizon/common/_limit_summary.html
+++ b/horizon/templates/horizon/common/_limit_summary.html
@@ -5,10 +5,8 @@
     <h3 class="quota-heading">{% trans "Limit Summary" %}</h3>
     {% for section in charts %}
       <h4>{{ section.title }}</h4>
+      <div class="row">
       {% for chart in section.charts %}
-        {% if forloop.first or forloop.counter0|divisibleby:6 %}
-          <div class="row">
-        {% endif %}
             <div class="d3_quota_bar col-lg-2 col-md-4 col-sm-4 col-xs-6">
               <div class="pie-chart-usage" data-used="{% quotapercent chart.used chart.quota %}"></div>
               <div class="quota_title" title="{{ chart.name }}" data-toggle="tooltip"> {{ chart.name }}</div>
@@ -24,12 +22,8 @@
                 {% endif %}
               </div>
             </div>
-        {% if forloop.last or forloop.counter|divisibleby:6 %}
-          {% if not forloop.first %}
-          </div>
-          {% endif %}
-        {% endif %}
       {% endfor %}
+      </div>
     {% endfor %}
   </div>
 {% endspaceless %}


### PR DESCRIPTION
When the displayed quotas are overridden to only show one chart, (such as showing instances, but not vcpu/memory under compute) the "row" html tag was not closed.

While this could be fixed by removing the check for "forloop.first" in the closing bounds check, a more robust fix seems to be moving the row open/close tags outside of the loop entirely.

Those checks were only in place to generate a new row every 6 columns, but that is now handled by the bootstrap column spec instead, so we can unconitionally generate a row for each section, and let bootstrap handle rendering/wrapping of the columns.