### PR TITLE
fix regressions introduced during 2023.1 rebase

### DIFF
--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -52,11 +52,14 @@
     var steps = $scope.steps = $scope.workflow.steps || [];
     $scope.wizardForm = {};
 
+    $scope.advanced = extend({showButton: false, showTabs: true}, $scope.workflow.advanced);
+
     // a place to keep each step's captured data, named for their step.formName
     $scope.stepModels = {};
 
     $scope.switchTo = switchTo;
     $scope.showError = showError;
+    $scope.toggleAdvanced = toggleAdvanced;
     ctrl.toggleHelpBtn = toggleHelpBtn;
     ctrl.onInitSuccess = onInitSuccess;
     ctrl.onInitError = onInitError;
@@ -69,6 +72,20 @@
     viewModel.hasError = false;
     viewModel.onClickFinishBtn = onClickFinishBtn;
     viewModel.isSubmitting = false;
+
+    $scope.showAdvancedButton = function() {
+      return $scope.advanced.showButton && !$scope.advanced.showTabs;
+    };
+    $scope.hideAdvancedButton = function() {
+      return $scope.advanced.showButton && $scope.advanced.showTabs;
+    };
+    $scope.shouldShowStep = function(step) {
+      if (step.isAdvanced) {
+        return step.ready && $scope.advanced.showTabs;
+      } else {
+        return step.ready;
+      }
+    };
 
     $scope.initPromise.then(onInitSuccess, onInitError);
 
@@ -96,6 +113,13 @@
       $scope.currentIndex = index;
       $scope.openHelp = false;
       /*eslint-enable angular/controller-as*/
+      if (steps[index].isAdvanced) {
+        $scope.advanced.showTabs = true;
+      }
+    }
+
+    function toggleAdvanced() {
+      $scope.advanced.showTabs = !$scope.advanced.showTabs;
     }
 
     function showError(errorMessage) {

--- a/horizon/static/framework/widgets/wizard/wizard.controller.js
+++ b/horizon/static/framework/widgets/wizard/wizard.controller.js
@@ -113,9 +113,6 @@
       $scope.currentIndex = index;
       $scope.openHelp = false;
       /*eslint-enable angular/controller-as*/
-      if (steps[index].isAdvanced) {
-        $scope.advanced.showTabs = true;
-      }
     }
 
     function toggleAdvanced() {

--- a/horizon/static/framework/widgets/wizard/wizard.html
+++ b/horizon/static/framework/widgets/wizard/wizard.html
@@ -27,7 +27,7 @@
                 ng-class="{'active': currentIndex===$index}"
                 ng-click="switchTo($index)"
                 ng-repeat="step in steps"
-                ng-show="step.ready">
+                ng-show="shouldShowStep(step)">
               <a href="#">
                 <span ng-bind="::step.title"></span>
                 <span class="hz-icon-required fa fa-asterisk"
@@ -65,6 +65,10 @@
       <span ng-class="::viewModel.btnIcon.cancel||'fa fa-close'"></span>
       <span ng-bind="::viewModel.btnText.cancel"></span>
     </button>
+    <button type="button" class="btn btn-default pull-left"
+            ng-click="toggleAdvanced()" ng-show="showAdvancedButton()">Show Advanced</button>
+    <button type="button" class="btn btn-default pull-left"
+            ng-click="toggleAdvanced()" ng-show="hideAdvancedButton()">Hide Advanced</button>
 
     <button type="button" class="btn btn-default back"
       ng-click="switchTo(currentIndex - 1)"

--- a/openstack_dashboard/api/nova.py
+++ b/openstack_dashboard/api/nova.py
@@ -97,6 +97,7 @@ class MKSConsole(base.APIDictWrapper):
     """
     _attrs = ['url', 'type']
 
+
 class Hypervisor(base.APIDictWrapper):
     """Simple wrapper around novaclient.hypervisors.Hypervisor."""
 

--- a/openstack_dashboard/dashboards/project/instances/forms.py
+++ b/openstack_dashboard/dashboards/project/instances/forms.py
@@ -83,18 +83,6 @@ class RebuildInstanceForm(forms.SelfHandlingForm):
             del self.fields['password']
             del self.fields['confirm_password']
 
-        # try:
-        #     if not api.nova.extension_supported("DiskConfig", request):
-        #         del self.fields['disk_config']
-        #     else:
-        #         # Set our disk_config choices
-        #         config_choices = [("AUTO", _("Automatic")),
-        #                           ("MANUAL", _("Manual"))]
-        #         self.fields['disk_config'].choices = config_choices
-        # except Exception:
-        #     exceptions.handle(request, _('Unable to retrieve extensions '
-        #                                  'information.'))
-
     def clean(self):
         cleaned_data = super().clean()
         if 'password' in cleaned_data:

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/flavor/flavor-details.html
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/flavor/flavor-details.html
@@ -6,14 +6,6 @@
         <pie-chart chart-data="item.instancesChartData"
                    chart-settings="chartSettings"></pie-chart>
       </div>
-      <div class="col-xs-4">
-        <pie-chart chart-data="item.vcpusChartData"
-                   chart-settings="chartSettings"></pie-chart>
-      </div>
-      <div class="col-xs-4">
-        <pie-chart chart-data="item.ramChartData"
-                   chart-settings="chartSettings"></pie-chart>
-      </div>
     </div>
     <div class="row" ng-if="ctrl.cinderLimits">
       <div class="col-xs-4">

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/flavor/flavor.controller.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/flavor/flavor.controller.js
@@ -346,6 +346,12 @@
         var errors = ctrl.getErrors(facade.flavor);
         facade.errors = errors;
         facade.enabled = Object.keys(errors).length === 0;
+
+        if (facade.enabled && facade.flavor.name == launchInstanceModel.default_flavor_name){
+          if (ctrl.allocatedFlavorFacades.length == 0) {
+            ctrl.allocatedFlavorFacades.push(facade)
+          }
+        }
       }
       
       // Set default flavor if only one available

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/flavor/flavor.controller.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/flavor/flavor.controller.js
@@ -102,29 +102,6 @@
       detailsTemplateUrl: basePath + 'flavor/flavor-details.html',
       columns: [
         {id: 'name', title: gettext('Name'), priority: 1},
-        {id: 'vcpus', title: gettext('VCPUS'), priority: 1,
-          template: `<span class="invalid fa fa-exclamation-triangle"
-            ng-show="item.errors.vcpus"
-            uib-popover="{$ item.errors.vcpus $}"
-            popover-placement="top" popover-append-to-body="true"
-            popover-trigger="'mouseenter'"></span>
-            <span>{$ item.vcpus $}</span>`},
-        {id: 'ram', title: gettext('RAM'), priority: 1,
-          template: `<span class="invalid fa fa-exclamation-triangle"
-            ng-show="item.errors.ram"
-            uib-popover="{$ item.errors.ram $}"
-            popover-placement="top" popover-append-to-body="true"
-            popover-trigger="'mouseenter'"></span>
-            <span>{$ item.ram | mb $}</span>`},
-        {id: 'totalDisk', title: gettext('Total Disk'), filters: ['gb'], priority: 1},
-        {id: 'rootDisk', title: gettext('Root Disk'), priority: 2,
-          template: `<span class="invalid fa fa-exclamation-triangle"
-            ng-show="item.errors.disk"
-            uib-popover="{$ item.errors.disk $}"
-            popover-placement="top" popover-append-to-body="true"
-            popover-trigger="'mouseenter'"></span>
-            <span>{$ item.rootDisk | gb $}</span>`},
-        {id: 'ephemeralDisk', title: gettext('Ephemeral Disk'), filters: ['gb'], priority: 2},
         {id: 'isPublic', title: gettext('Public'), filters: ['yesno'], priority: 1}
       ]
     };
@@ -310,20 +287,6 @@
         var createVolume = launchInstanceModel.newInstanceSpec.vol_create;
 
         facade.instancesChartData = instancesChartData;
-
-        facade.vcpusChartData = ctrl.getChartData(
-          ctrl.chartTotalVcpusLabel,
-          ctrl.instanceCount * facade.vcpus,
-          launchInstanceModel.novaLimits.totalCoresUsed,
-          launchInstanceModel.novaLimits.maxTotalCores);
-
-        facade.ramChartData = ctrl.getChartData(
-          ctrl.chartTotalRamLabel,
-          ctrl.instanceCount * facade.ram,
-          launchInstanceModel.novaLimits.totalRAMUsed,
-          launchInstanceModel.novaLimits.maxTotalRAMSize,
-          "MB"
-        );
 
         if (launchInstanceModel.cinderLimits) {
           facade.volumeChartData = ctrl.getChartData(

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/flavor/flavor.controller.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/flavor/flavor.controller.js
@@ -251,8 +251,10 @@
       if (allocatedFlavors && allocatedFlavors.length > 0) {
         var allocatedFlavorFacade = allocatedFlavors[0];
         var isValid = allocatedFlavorFacade.enabled;
-        $scope.launchInstanceFlavorForm['allocated-flavor']
-              .$setValidity('flavor', isValid);
+        if ($scope.launchInstanceFlavorForm){
+          $scope.launchInstanceFlavorForm['allocated-flavor']
+                .$setValidity('flavor', isValid);
+        }
       }
     }
 
@@ -279,11 +281,6 @@
           extras:        flavor.extras
         };
         ctrl.availableFlavorFacades.push(facade);
-      }
-
-      // Set default flavor if only one available
-      if(ctrl.allocatedFlavorFacades.length < 1 && ctrl.availableFlavorFacades.length == 1){
-        ctrl.allocatedFlavorFacades.push(ctrl.availableFlavorFacades[0]);
       }
     }
 
@@ -349,6 +346,11 @@
         var errors = ctrl.getErrors(facade.flavor);
         facade.errors = errors;
         facade.enabled = Object.keys(errors).length === 0;
+      }
+      
+      // Set default flavor if only one available
+      if(ctrl.allocatedFlavorFacades.length < 1 && ctrl.availableFlavorFacades.length == 1 && ctrl.availableFlavorFacades[0].enabled){
+        ctrl.allocatedFlavorFacades.push(ctrl.availableFlavorFacades[0]);
       }
     }
 

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-model.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-model.service.js
@@ -313,6 +313,9 @@
       if ('default_availability_zone' in defaults) {
         model.default_availability_zone = defaults.default_availability_zone;
       }
+      if ('default_flavor_name' in defaults) {
+        model.default_flavor_name = defaults.default_flavor_name;
+      }
     }
 
     /**

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -50,7 +50,8 @@
           title: gettext('Flavor'),
           templateUrl: basePath + 'flavor/flavor.html',
           helpUrl: basePath + 'flavor/flavor.help.html',
-          formName: 'launchInstanceFlavorForm'
+          formName: 'launchInstanceFlavorForm',
+          isAdvanced: true,
         },
         {
           id: 'networks',
@@ -67,7 +68,8 @@
           helpUrl: basePath + 'networkports/ports.help.html',
           formName: 'launchInstanceNetworkPortForm',
           requiredServiceTypes: ['network'],
-          setting: 'LAUNCH_INSTANCE_DEFAULTS.enable_net_ports'
+          setting: 'LAUNCH_INSTANCE_DEFAULTS.enable_net_ports',
+          isAdvanced: true,
         },
         {
           id: 'secgroups',
@@ -75,7 +77,8 @@
           templateUrl: basePath + 'security-groups/security-groups.html',
           helpUrl: basePath + 'security-groups/security-groups.help.html',
           formName: 'launchInstanceAccessAndSecurityForm',
-          requiredServiceTypes: ['network']
+          requiredServiceTypes: ['network'],
+          isAdvanced: true,
         },
         {
           id: 'keypair',
@@ -89,7 +92,8 @@
           title: gettext('Configuration'),
           templateUrl: basePath + 'configuration/configuration.html',
           helpUrl: basePath + 'configuration/configuration.help.html',
-          formName: 'launchInstanceConfigurationForm'
+          formName: 'launchInstanceConfigurationForm',
+          isAdvanced: true,
         },
         {
           id: 'servergroups',
@@ -97,7 +101,8 @@
           templateUrl: basePath + 'server-groups/server-groups.html',
           helpUrl: basePath + 'server-groups/server-groups.help.html',
           formName: 'launchInstanceServerGroupsForm',
-          policy: stepPolicy.serverGroups
+          policy: stepPolicy.serverGroups,
+          isAdvanced: true,
         },
         {
           id: 'hints',
@@ -106,7 +111,8 @@
           helpUrl: basePath + 'scheduler-hints/scheduler-hints.help.html',
           formName: 'launchInstanceSchedulerHintsForm',
           policy: stepPolicy.schedulerHints,
-          setting: 'LAUNCH_INSTANCE_DEFAULTS.enable_scheduler_hints'
+          setting: 'LAUNCH_INSTANCE_DEFAULTS.enable_scheduler_hints',
+          isAdvanced: true,
         },
         {
           id: 'metadata',
@@ -114,7 +120,8 @@
           templateUrl: basePath + 'metadata/metadata.html',
           helpUrl: basePath + 'metadata/metadata.help.html',
           formName: 'launchInstanceMetadataForm',
-          setting: 'LAUNCH_INSTANCE_DEFAULTS.enable_metadata'
+          setting: 'LAUNCH_INSTANCE_DEFAULTS.enable_metadata',
+          isAdvanced: true,
         }
       ],
 
@@ -124,6 +131,11 @@
 
       btnIcon: {
         finish: 'fa-cloud-upload'
+      },
+
+      advanced: {
+        showButton: true,
+        showTabs: false,
       }
     });
   }

--- a/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
+++ b/openstack_dashboard/dashboards/project/static/dashboard/project/workflow/launch-instance/launch-instance-workflow.service.js
@@ -78,6 +78,7 @@
           helpUrl: basePath + 'security-groups/security-groups.help.html',
           formName: 'launchInstanceAccessAndSecurityForm',
           requiredServiceTypes: ['network'],
+          setting: 'LAUNCH_INSTANCE_DEFAULTS.enable_secgroups',
           isAdvanced: true,
         },
         {
@@ -102,6 +103,7 @@
           helpUrl: basePath + 'server-groups/server-groups.help.html',
           formName: 'launchInstanceServerGroupsForm',
           policy: stepPolicy.serverGroups,
+          setting: 'LAUNCH_INSTANCE_DEFAULTS.enable_servergroups',
           isAdvanced: true,
         },
         {

--- a/openstack_dashboard/defaults.py
+++ b/openstack_dashboard/defaults.py
@@ -253,6 +253,8 @@ LAUNCH_INSTANCE_DEFAULTS = {
     'enable_scheduler_hints': True,
     'enable_metadata': True,
     'enable_net_ports': True,
+    'enable_secgroups': True,
+    'enable_servergroups': True,
     'default_availability_zone': 'Any',
 }
 

--- a/openstack_dashboard/defaults.py
+++ b/openstack_dashboard/defaults.py
@@ -255,6 +255,7 @@ LAUNCH_INSTANCE_DEFAULTS = {
     'enable_net_ports': True,
     'enable_secgroups': True,
     'enable_servergroups': True,
+    'default_flavor_name': None,
     'default_availability_zone': 'Any',
 }
 

--- a/openstack_dashboard/enabled/_1110_project_server_groups_panel.py
+++ b/openstack_dashboard/enabled/_1110_project_server_groups_panel.py
@@ -6,5 +6,6 @@ PANEL_DASHBOARD = 'project'
 PANEL_GROUP = 'compute'
 
 # Python panel class of the PANEL to be added.
-ADD_PANEL = ('openstack_dashboard.dashboards.project.server_groups'
-             '.panel.ServerGroups')
+# NOTE: This panel is disabled because server groups are unused
+# ADD_PANEL = ('openstack_dashboard.dashboards.project.server_groups'
+#              '.panel.ServerGroups')

--- a/openstack_dashboard/enabled/_1480_security_groups_panel.py
+++ b/openstack_dashboard/enabled/_1480_security_groups_panel.py
@@ -2,5 +2,6 @@ PANEL_DASHBOARD = 'project'
 PANEL_GROUP = 'network'
 PANEL = 'security_groups'
 
-ADD_PANEL = ('openstack_dashboard.dashboards.project.security_groups'
-             '.panel.SecurityGroups')
+# Security groups don't work on bare metal sites, so we don't load them there
+# ADD_PANEL = ('openstack_dashboard.dashboards.project.security_groups'
+#              '.panel.SecurityGroups')


### PR DESCRIPTION
this PR holds a queue of changes that we had previously introduced in train and xena, and didn't make it into the 2023.1 rebase.

New features introduced to try and fix these:
1. instance launch form: security group and server group tabs can now be hidden via `LAUNCH_INSTANCE_DEFAULTS` setting
2. auto-selected default flavor can be configured via `LAUNCH_INSTANCE_DEFAULTS`.

Fixes:
1. fixed errors from setting a default flavor prior to form loading fully
2. default flavor now honors flavor "filters", and will not be selected if it would violate quota
3. `show advanced` tab no longer auto-shows if a sequentially "later" tab is clicked, such as keypairs after flavors

Remaining un-fixed issues to be addressed later:
1. Image and instance creator name are not shown, due to incomplete prior implementation. Postponing this feature.
2. chameleon supported images are not sortable/filterable in either the instance launch dialog or the images table. The prior implementation supported sort, but not filtering, and is fairly brittle.
3. blazar-dashboard: up/down arrows on numerical selectors do not work on click. 
4. blazar-dashboard: angularJS warnings from use of `attr` instead of `prop`

Remaining tech debt which will need to be reverted:
1. server_group and security group panels are disabled in the source here, rather than via overide at deploy time
2. flavor info (vcpus, ram, etc...) are hidden/removed in the source, rather than being configurable at deploy time
3. "chameleon supported" logo is added via modification to `hz-dynamic-table`, rather than to some user of that class in the images JS. Logo is also pulled from chameleoncloud.org, rather than being bundled into static content.