### PR TITLE
Use chameleon-supported metadata on the image

### DIFF
--- a/horizon/static/framework/widgets/table/hz-dynamic-table.html
+++ b/horizon/static/framework/widgets/table/hz-dynamic-table.html
@@ -72,7 +72,12 @@
             </div>
           </td>
           <td style="width: 4em;max-width: 5em;" ng-show="config.expand" class="expander">
-            <img title="Chameleon Supported Appliance" style="float:right;" ng-if="item.project_supported" height="20px" src="https://www.chameleoncloud.org/static/images/logo-small.png" />
+            <img
+              title="Chameleon Supported Appliance"
+              style="float:right;"
+              ng-if="item.project_supported && (item.project_supported.toLowerCase() === 'yes' || item.project_supported.toLowerCase() === 'deprecated')"
+              height="20px"
+              src="https://www.chameleoncloud.org/static/images/logo-small.png" />
             <div class="fa fa-chevron-right"
               hz-expand-detail
               duration="200">

--- a/horizon/static/framework/widgets/table/hz-dynamic-table.html
+++ b/horizon/static/framework/widgets/table/hz-dynamic-table.html
@@ -75,7 +75,7 @@
             <img
               title="Chameleon Supported Appliance"
               style="float:right;"
-              ng-if="item.project_supported && (item.project_supported.toLowerCase() === 'yes' || item.project_supported.toLowerCase() === 'deprecated')"
+              ng-if="item.project_supported && (item.project_supported.toLowerCase() === 'true' || item.project_supported.toLowerCase() === 'yes' || item.project_supported.toLowerCase() === 'deprecated')"
               height="20px"
               src="https://www.chameleoncloud.org/static/images/logo-small.png" />
             <div class="fa fa-chevron-right"

--- a/openstack_dashboard/api/glance.py
+++ b/openstack_dashboard/api/glance.py
@@ -80,7 +80,8 @@ class Image(base.APIResourceWrapper):
 
     @property
     def project_supported(self):
-        return self.get_is_project_supported()
+        value = getattr(self._apiresource, 'chameleon-supported', False)
+        return str(value).lower() == 'true'
 
     @property
     def published_in_app_catalog(self):
@@ -137,9 +138,6 @@ class Image(base.APIResourceWrapper):
 
     def get_catalog_id(self):
         return Image._published_appliances.get(self.id, {}).get('id', -1)
-
-    def get_is_project_supported(self):
-        return Image._published_appliances.get(self.id, {}).get('project_supported', False)
 
     def get_is_published_in_app_catalog(self):
         return Image._published_appliances.get(self.id) is not None

--- a/openstack_dashboard/api/glance.py
+++ b/openstack_dashboard/api/glance.py
@@ -85,7 +85,7 @@ class Image(base.APIResourceWrapper):
         if not settings.SHOW_CHAMELEON_SUPPORT_COLUMN:
             return str(self.get_is_project_supported())
 
-        raw = getattr(self._apiresource, 'chameleon-supported', None)
+        raw = getattr(self._apiresource, settings.CHAMELEON_SUPPORT_METADATA_NAME, None)
         if raw is None or str(raw).strip() == "":
             return 'No'
 

--- a/openstack_dashboard/api/glance.py
+++ b/openstack_dashboard/api/glance.py
@@ -83,7 +83,7 @@ class Image(base.APIResourceWrapper):
         # Use the old way (for now) to get the project_supported attribute
         # if the site is not showing the Chameleon Support column
         if not settings.SHOW_CHAMELEON_SUPPORT_COLUMN:
-            return self.get_is_project_supported()
+            return str(self.get_is_project_supported())
 
         raw = getattr(self._apiresource, 'chameleon-supported', None)
         if raw is None or str(raw).strip() == "":

--- a/openstack_dashboard/api/glance.py
+++ b/openstack_dashboard/api/glance.py
@@ -80,6 +80,11 @@ class Image(base.APIResourceWrapper):
 
     @property
     def project_supported(self):
+        # Use the old way (for now) to get the project_supported attribute
+        # if the site is not showing the Chameleon Support column
+        if not settings.SHOW_CHAMELEON_SUPPORT_COLUMN:
+            return self.get_is_project_supported()
+
         raw = getattr(self._apiresource, 'chameleon-supported', None)
         if raw is None or str(raw).strip() == "":
             return 'No'
@@ -149,6 +154,9 @@ class Image(base.APIResourceWrapper):
 
     def get_catalog_id(self):
         return Image._published_appliances.get(self.id, {}).get('id', -1)
+
+    def get_is_project_supported(self):
+        return Image._published_appliances.get(self.id, {}).get('project_supported', False)
 
     def get_is_published_in_app_catalog(self):
         return Image._published_appliances.get(self.id) is not None

--- a/openstack_dashboard/api/glance.py
+++ b/openstack_dashboard/api/glance.py
@@ -80,8 +80,19 @@ class Image(base.APIResourceWrapper):
 
     @property
     def project_supported(self):
-        value = getattr(self._apiresource, 'chameleon-supported', False)
-        return str(value).lower() == 'true'
+        raw = getattr(self._apiresource, 'chameleon-supported', None)
+        if raw is None or str(raw).strip() == "":
+            return 'No'
+
+        value = str(raw).strip().lower()
+        if value in ('true', 'yes'):
+            return 'Yes'
+        elif value in ('false', 'no'):
+            return 'No'
+        elif value == 'deprecated':
+            return 'Deprecated'
+        else:
+            return 'Unknown'
 
     @property
     def published_in_app_catalog(self):

--- a/openstack_dashboard/settings.py
+++ b/openstack_dashboard/settings.py
@@ -52,6 +52,8 @@ DEBUG = False
 
 ROOT_URLCONF = 'openstack_dashboard.urls'
 
+SHOW_CHAMELEON_SUPPORT_COLUMN = True
+
 HORIZON_CONFIG = {
     'user_home': 'openstack_dashboard.views.get_user_home',
     'ajax_queue_limit': 10,
@@ -71,7 +73,8 @@ HORIZON_CONFIG = {
     'js_spec_files': [],
     'external_templates': [],
     'plugins': [],
-    'integration_tests_support': INTEGRATION_TESTS_SUPPORT
+    'integration_tests_support': INTEGRATION_TESTS_SUPPORT,
+    'show_chameleon_support_column': SHOW_CHAMELEON_SUPPORT_COLUMN,
 }
 
 MIDDLEWARE = (

--- a/openstack_dashboard/settings.py
+++ b/openstack_dashboard/settings.py
@@ -53,6 +53,7 @@ DEBUG = False
 ROOT_URLCONF = 'openstack_dashboard.urls'
 
 SHOW_CHAMELEON_SUPPORT_COLUMN = True
+CHAMELEON_SUPPORT_METADATA_NAME = 'chameleon-supported'
 
 HORIZON_CONFIG = {
     'user_home': 'openstack_dashboard.views.get_user_home',

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -92,10 +92,10 @@
         classes: "word-wrap",
         urlFunction: imagesService.getDetailsPath
       })
-      // .append({
-      //   id: 'project_supported',
-      //   priority: 1
-      // })
+      .append({
+        id: 'project_supported',
+        priority: 1
+      })
       .append({
         id: 'type',
         priority: 1
@@ -130,18 +130,32 @@
         singleton: true,
         persistent: true
       })
-      // filtering by project supported not working yet, and it's not part of the requirements
-      // .append({
-      //   label: gettext('Project Supported'),
-      //   name: 'project_supported',
-      //   isServer: true,
-      //   singleton: true,
-      //   persistent: true,
-      //   options: [
-      //     {label: gettext('True'), key: 'true'},
-      //     {label: gettext('False'), key: 'false'}
-      //   ]
-      // })
+      .append({
+        label: gettext('Chameleon Support'),
+        name: 'project_supported',
+        isServer: true,
+        singleton: true,
+        persistent: true,
+        options: [
+          { label: gettext('Yes'), key: 'yes' },
+          { label: gettext('No'), key: 'no' },
+          { label: gettext('Deprecated'), key: 'deprecated' }
+        ],
+        filterFunction: function (value) {
+          switch (String(value).toLowerCase()) {
+            case 'yes':
+            case 'true':
+              return 'yes';
+            case 'no':
+            case 'false':
+              return 'no';
+            case 'deprecated':
+              return 'deprecated';
+            default:
+              return 'unknown';
+          }
+        }
+      })
       .append({
         label: gettext('Status'),
         name: 'status',
@@ -254,7 +268,7 @@
   function imageProperties(imagesService, statuses) {
     return {
       id: gettext('ID'),
-      project_supported: gettext('Project Supported'),
+      project_supported: gettext('Chameleon Support'),
       checksum: gettext('Checksum'),
       members: gettext('Members'),
       min_disk: gettext('Min. Disk'),

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -70,7 +70,8 @@
                imageResourceType,
                $memoize,
                keystone) {
-    registry.getResourceType(imageResourceType)
+
+    const columns = registry.getResourceType(imageResourceType)
       .setNames('Image', 'Images', ngettext('Image', 'Images', 1))
       .setSummaryTemplateUrl(basePath + 'details/drawer.html')
       .setDefaultIndexUrl('/project/images/')
@@ -78,7 +79,9 @@
       .setProperties(imageProperties(imagesService, statuses))
       .setListFunction(imagesService.getImagesPromise)
       .setNeedsFilterFirstFunction(imagesService.getFilterFirstSettingPromise)
-      .tableColumns
+      .tableColumns;
+
+    columns
       .append({
         id: 'owner',
         priority: 1,
@@ -91,11 +94,17 @@
         sortDefault: true,
         classes: "word-wrap",
         urlFunction: imagesService.getDetailsPath
-      })
-      .append({
-        id: 'project_supported',
-        priority: 1
-      })
+      });
+
+    if (window.horizon?.conf?.show_chameleon_support_column) {
+      columns
+        .append({
+          id: 'project_supported',
+          priority: 1
+        });
+    }
+
+    columns
       .append({
         id: 'type',
         priority: 1
@@ -122,40 +131,48 @@
         priority: 2
       });
 
-    registry.getResourceType(imageResourceType).filterFacets
+    const facets = registry.getResourceType(imageResourceType).filterFacets
+
+    facets
       .append({
         label: gettext('Name'),
         name: 'name',
         isServer: true,
         singleton: true,
         persistent: true
-      })
-      .append({
-        label: gettext('Chameleon Support'),
-        name: 'project_supported',
-        isServer: true,
-        singleton: true,
-        persistent: true,
-        options: [
-          { label: gettext('Yes'), key: 'yes' },
-          { label: gettext('No'), key: 'no' },
-          { label: gettext('Deprecated'), key: 'deprecated' }
-        ],
-        filterFunction: function (value) {
-          switch (String(value).toLowerCase()) {
-            case 'yes':
-            case 'true':
-              return 'yes';
-            case 'no':
-            case 'false':
-              return 'no';
-            case 'deprecated':
-              return 'deprecated';
-            default:
-              return 'unknown';
+      });
+
+    if (window.horizon?.conf?.show_chameleon_support_column) {
+      facets
+        .append({
+          label: gettext('Chameleon Support'),
+          name: 'project_supported',
+          isServer: true,
+          singleton: true,
+          persistent: true,
+          options: [
+            { label: gettext('Yes'), key: 'yes' },
+            { label: gettext('No'), key: 'no' },
+            { label: gettext('Deprecated'), key: 'deprecated' }
+          ],
+          filterFunction: function (value) {
+            switch (String(value).toLowerCase()) {
+              case 'yes':
+              case 'true':
+                return 'yes';
+              case 'no':
+              case 'false':
+                return 'no';
+              case 'deprecated':
+                return 'deprecated';
+              default:
+                return 'unknown';
+            }
           }
-        }
-      })
+        });
+    }
+
+    facets
       .append({
         label: gettext('Status'),
         name: 'status',

--- a/openstack_dashboard/templates/horizon/_conf.html
+++ b/openstack_dashboard/templates/horizon/_conf.html
@@ -38,6 +38,8 @@
     };
     conf.disable_password_reveal =
       {{ HORIZON_CONFIG.disable_password_reveal|yesno:"true,false" }};
+    conf.show_chameleon_support_column =
+      {{ HORIZON_CONFIG.show_chameleon_support_column|yesno:"true,false" }};
 
   })(this);
 </script>


### PR DESCRIPTION
For now I left `fetch_published_appliances` related stuff in since it appears related to other things like the code denoting whether or not the image is published in the catalog or not. I'm not entirely sure where all that is used (and if we want it to be or not).

Do we want to still use the catalog for older images? Obviously this initial change only works for new images we build and push.