### PR TITLE
Revert number input styles to default HTML5

### DIFF
--- a/openstack_dashboard/static/dashboard/scss/components/_spinners.scss
+++ b/openstack_dashboard/static/dashboard/scss/components/_spinners.scss
@@ -1,11 +1,12 @@
 .themable-spinner {
   display: flex;
 
-  // Remove default spinner styles here
-  // **********************************
-  input {
-    -moz-appearance: textfield;
-  }
+  // Re-add default spinner styles here
+  // // Remove default spinner styles here
+  // // **********************************
+  // input {
+  //   -moz-appearance: textfield;
+  // }
 
   & input::-webkit-inner-spin-button,
   & input::-webkit-outer-spin-button {
@@ -26,6 +27,8 @@
   }
 
   .input-group-btn-vertical {
+    // (Chameleon) Hide spinner buttons
+    display: none;
 
     .btn {
       line-height: 1;


### PR DESCRIPTION
The Horizon Django number input form is overridden with this custom spinner component, which adds in custom up/down buttons. This change hides those buttons, and reverts the input style to show the browser default behavior. This seems to only affect blazar-dashboard lease create, as everywhere else is using angular.