### PR TITLE
fix: ensure hardware_catalog_url is defined

### DIFF
--- a/openstack_dashboard/dashboards/project/instances/tabs.py
+++ b/openstack_dashboard/dashboards/project/instances/tabs.py
@@ -38,6 +38,7 @@ class OverviewTab(tabs.Tab):
 
     def get_context_data(self, request):
         site = None
+        hardware_catalog_url = None
         if settings.CHAMELEON_MULTISITE_SUPPORT:
             site = settings.CHAMELEON_SITE_ID
         elif settings.CHAMELEON_SITES:


### PR DESCRIPTION
Just make sure hardware_catalog_url is defined, even if settings.CHAMELEON_MULTISITE_SUPPORT and settings.CHAMELEON_SITES aren't set.