### PR TITLE
fix: lazy import blazar_dashboard

### DIFF
--- a/openstack_dashboard/api/rest/blazar.py
+++ b/openstack_dashboard/api/rest/blazar.py
@@ -4,8 +4,10 @@ from openstack_dashboard import api
 from openstack_dashboard.api.rest import urls
 from openstack_dashboard.api.rest import utils as rest_utils
 
-from blazar_dashboard.api.client import lease_list
-
+try:
+    from blazar_dashboard.api.client import lease_list
+except ImportError as ex:
+    lease_list = None
 
 @urls.register
 class Reservations(generic.View):


### PR DESCRIPTION
We've located the reservations horizon API within horizon's repo, rather than in the blazar-dashboard repo. If the blazar_dashboard package isn't installed, horizon will fail to start.

Move blazar_dashboard import behind a try/except so that unit-tests can pass. Proper fix is to move the logic depending on it out of this repo entirely.